### PR TITLE
Add readonly mode support to gizmosql startup scripts

### DIFF
--- a/scripts/start_gizmosql.sh
+++ b/scripts/start_gizmosql.sh
@@ -9,6 +9,7 @@ L_DATABASE_BACKEND=${1:-${DATABASE_BACKEND:-"duckdb"}}
 L_DATABASE_FILENAME=${2:-${DATABASE_FILENAME:-"data/TPC-H-small.duckdb"}}
 L_TLS_ENABLED=${3:-${TLS_ENABLED:-"1"}}
 L_PRINT_QUERIES=${4:-${PRINT_QUERIES:-"1"}}
+L_READONLY=${5:-${READONLY:-"0"}}
 
 TLS_ARG=""
 if [ "${L_TLS_ENABLED}" == "1" ]
@@ -30,4 +31,11 @@ then
   PRINT_QUERIES_FLAG="--print-queries"
 fi
 
-gizmosql_server --backend="${L_DATABASE_BACKEND}" --database-filename="${L_DATABASE_FILENAME}" ${TLS_ARG} ${PRINT_QUERIES_FLAG}
+# Setup the readonly option
+READONLY_FLAG=""
+if [ "${L_READONLY}" == "1" ]
+then
+  READONLY_FLAG="--readonly"
+fi
+
+gizmosql_server --backend="${L_DATABASE_BACKEND}" --database-filename="${L_DATABASE_FILENAME}" ${TLS_ARG} ${PRINT_QUERIES_FLAG} ${READONLY_FLAG}

--- a/scripts/start_gizmosql_slim.sh
+++ b/scripts/start_gizmosql_slim.sh
@@ -8,6 +8,7 @@ L_PRINT_QUERIES=${3:-${PRINT_QUERIES:-"1"}}
 L_TLS_ENABLED=${4:-${TLS_ENABLED:-"0"}}
 L_TLS_CERT=${5:-${TLS_CERT}}
 L_TLS_KEY=${6:-${TLS_KEY}}
+L_READONLY=${7:-${READONLY:-"0"}}
 
 TLS_ARG=""
 if [ "${L_TLS_ENABLED}" == "1" ]
@@ -29,4 +30,11 @@ then
   PRINT_QUERIES_FLAG="--print-queries"
 fi
 
-gizmosql_server --backend="${L_DATABASE_BACKEND}" --database-filename="${L_DATABASE_FILENAME}" ${TLS_ARG} ${PRINT_QUERIES_FLAG}
+# Setup the readonly option
+READONLY_FLAG=""
+if [ "${L_READONLY}" == "1" ]
+then
+  READONLY_FLAG="--readonly"
+fi
+
+gizmosql_server --backend="${L_DATABASE_BACKEND}" --database-filename="${L_DATABASE_FILENAME}" ${TLS_ARG} ${PRINT_QUERIES_FLAG} ${READONLY_FLAG}


### PR DESCRIPTION
Introduces the `--readonly` flag to both `start_gizmosql.sh` and `start_gizmosql_slim.sh` for enabling read-only mode. This allows greater control over database accessibility based on the `READONLY` environment variable or command-line argument.