### PR TITLE
Upgrade DuckDB and dependencies to version 1.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,7 +105,7 @@ RUN cmake -S . -B build -G Ninja \
 COPY --chown=app_user:app_user ./tls ./tls
 
 # Install DuckDB CLI for troubleshooting, etc.
-ARG DUCKDB_VERSION="1.2.2"
+ARG DUCKDB_VERSION="1.3.0"
 
 RUN case ${TARGETPLATFORM} in \
          "linux/amd64")  DUCKDB_FILE=https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-amd64.zip  ;; \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -95,7 +95,7 @@ RUN chmod +x /usr/local/bin/gizmosql_client
 COPY --chown=app_user:app_user tls tls
 
 # Install DuckDB CLI for troubleshooting, etc.
-ARG DUCKDB_VERSION="1.2.2"
+ARG DUCKDB_VERSION="1.3.0"
 
 RUN case ${TARGETPLATFORM} in \
          "linux/amd64")  DUCKDB_FILE=https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-amd64.zip  ;; \

--- a/README.md
+++ b/README.md
@@ -58,15 +58,15 @@ The above command will automatically mount a very small TPC-H DuckDB database fi
 **Note**: You can disable TLS in the container by setting environment variable: `TLS_ENABLED` to "0" (default is "1" - enabled).  This is not recommended unless you are using an mTLS sidecar in Kubernetes or something similar, as it will be insecure.    
 
 ### Optional - open a different database file
-When running the Docker image - you can have it run your own DuckDB database file (the database must be built with DuckDB version: 1.2.2).   
+When running the Docker image - you can have it run your own DuckDB database file (the database must be built with DuckDB version: 1.3.0).   
 
 Prerequisite: DuckDB CLI   
-Install DuckDB CLI version [1.2.2](https://github.com/duckdb/duckdb/releases/tag/v1.2.2) - and make sure the executable is on your PATH.
+Install DuckDB CLI version [1.3.0](https://github.com/duckdb/duckdb/releases/tag/v1.3.0) - and make sure the executable is on your PATH.
 
 Platform Downloads:   
-[Linux x86-64](https://github.com/duckdb/duckdb/releases/download/v1.2.2/duckdb_cli-linux-amd64.zip)   
-[Linux arm64 (aarch64)](https://github.com/duckdb/duckdb/releases/download/v1.2.2/duckdb_cli-linux-aarch64.zip)   
-[MacOS Universal](https://github.com/duckdb/duckdb/releases/download/v1.2.2/duckdb_cli-osx-universal.zip)
+[Linux x86-64](https://github.com/duckdb/duckdb/releases/download/v1.3.0/duckdb_cli-linux-amd64.zip)   
+[Linux arm64 (aarch64)](https://github.com/duckdb/duckdb/releases/download/v1.3.0/duckdb_cli-linux-aarch64.zip)   
+[MacOS Universal](https://github.com/duckdb/duckdb/releases/download/v1.3.0/duckdb_cli-osx-universal.zip)
 
 In this example, we'll generate a new TPC-H Scale Factor 1 (1GB) database file, and then run the docker image to mount it:
 
@@ -227,7 +227,7 @@ version(): string
 
 Results:
 version():   [
-    "v1.2.2"
+    "v1.3.0"
   ]
 
 Total: 1
@@ -330,7 +330,7 @@ Licensed by: "GizmoData LLC"
 ----------------------------------------------
 Apache Arrow version: 20.0.0
 WARNING - TLS is disabled for the GizmoSQL server - this is insecure.
-DuckDB version: v1.2.2
+DuckDB version: v1.3.0
 Running Init SQL command: 
 SET autoinstall_known_extensions = true;
 Running Init SQL command: 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pandas==2.2.*
-duckdb==1.2.2
-click==8.1.*
+duckdb==1.3.*
+click==8.2.*
 pyarrow==20.0.0
-adbc-driver-flightsql==1.5.*
-adbc-driver-manager==1.5.*
+adbc-driver-flightsql==1.6.*
+adbc-driver-manager==1.6.*

--- a/third_party/DuckDB_CMakeLists.txt.in
+++ b/third_party/DuckDB_CMakeLists.txt.in
@@ -9,7 +9,7 @@ ExternalProject_Add(
     duckdb_project
     PREFIX ${CMAKE_BINARY_DIR}/third_party
     GIT_REPOSITORY https://github.com/duckdb/duckdb
-    GIT_TAG v1.2.2
+    GIT_TAG v1.3.0
     CMAKE_ARGS
           -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/third_party/duckdb
 )


### PR DESCRIPTION
Updated DuckDB and related dependencies across the project to version 1.3.0. This includes Dockerfiles, CMakeLists, README, and `requirements.txt`. Ensures compatibility and leverages the latest features and fixes in DuckDB.