### PR TITLE
Update DuckDB arm64 download URL to correct filename

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,7 @@ ARG DUCKDB_VERSION="1.3.0"
 
 RUN case ${TARGETPLATFORM} in \
          "linux/amd64")  DUCKDB_FILE=https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-amd64.zip  ;; \
-         "linux/arm64")  DUCKDB_FILE=https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-aarch64.zip  ;; \
+         "linux/arm64")  DUCKDB_FILE=https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-arm64.zip  ;; \
     esac && \
     curl --output /tmp/duckdb.zip --location ${DUCKDB_FILE} && \
     unzip /tmp/duckdb.zip -d /usr/local/bin && \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -99,7 +99,7 @@ ARG DUCKDB_VERSION="1.3.0"
 
 RUN case ${TARGETPLATFORM} in \
          "linux/amd64")  DUCKDB_FILE=https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-amd64.zip  ;; \
-         "linux/arm64")  DUCKDB_FILE=https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-aarch64.zip  ;; \
+         "linux/arm64")  DUCKDB_FILE=https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-arm64.zip  ;; \
     esac && \
     curl --output /tmp/duckdb.zip --location ${DUCKDB_FILE} && \
     unzip /tmp/duckdb.zip -d /usr/local/bin && \

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Install DuckDB CLI version [1.3.0](https://github.com/duckdb/duckdb/releases/tag
 
 Platform Downloads:   
 [Linux x86-64](https://github.com/duckdb/duckdb/releases/download/v1.3.0/duckdb_cli-linux-amd64.zip)   
-[Linux arm64 (aarch64)](https://github.com/duckdb/duckdb/releases/download/v1.3.0/duckdb_cli-linux-aarch64.zip)   
+[Linux arm64 (aarch64)](https://github.com/duckdb/duckdb/releases/download/v1.3.0/duckdb_cli-linux-arm64.zip)   
 [MacOS Universal](https://github.com/duckdb/duckdb/releases/download/v1.3.0/duckdb_cli-osx-universal.zip)
 
 In this example, we'll generate a new TPC-H Scale Factor 1 (1GB) database file, and then run the docker image to mount it:


### PR DESCRIPTION
Replaced "aarch64" with "arm64" in DuckDB URLs across Dockerfiles and README for consistency with DuckDB's release naming conventions. This ensures compatibility and avoids potential download errors for arm64 platforms.