### PR TITLE
Support direct attach to DuckLake

### DIFF
--- a/src/library/gizmosql_library.cpp
+++ b/src/library/gizmosql_library.cpp
@@ -169,7 +169,8 @@ arrow::Result<std::shared_ptr<flight::sql::FlightSqlServerBase>> CreateFlightSQL
                  "database..."
               << std::endl;
     database_filename = ":memory:";
-  } else {
+  } else if (database_filename.u8string().find(':') == std::string::npos) {
+    // DuckDB supports '<extension_name>:...' syntax, for example 'ducklake:/path/to/lake.db'
     // We do not check for existence of the database file, b/c they may want to create a new one
     database_filename = fs::absolute(database_filename);
   }


### PR DESCRIPTION
[DuckLake](https://ducklake.select/) is an extension for DuckDB.

In general, to connect to a DuckLake instance, user first needs to open a connection to an ordinary DuckDB instance (in-memory or file one) and then run `ATTACH` query like this:

```
ATTACH 'ducklake:postgres:postgresql://user:pwd@127.0.0.1:5432/lake1' AS lake1
```

to attach the DuckLake instance as new DB with `lake1` alias.

DuckLake additionally supports direct-attach (duckdb/ducklake#201) syntax, when the DuckLake connection URL is specified for the initial database name, for exaple with DuckDB CLI:

```
./duckdb ducklake:postgres:postgresql://user:pwd@127.0.0.1:5432/lake1
```

In this case the DuckLake `lake1` DB will be attached as the only DB instance, so DuckLake tables can be accessed without specifying the DB name. This syntax is also supported in DuckDB JDBC/ODBC drivers and in other language clients.

This change adds a check, that when `database_filename` contains `:` character, then it is likely a direct-attach URL (or, perhaps, an absolute path on Windows) and it is not necessary to convert it to an absolute path.

Fixes: #21