### PR TITLE
Add versions table

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ For more information about Apache Arrow Flight SQL - please see this [article](h
 
 It is originally **forked from [`sqlflite`](https://github.com/voltrondata/sqlflite)**, an open-source project developed by Voltron Data. I contributed to `sqlflite` while employed at Voltron Data, and have since independently extended and evolved the project into GizmoSQL under the Apache 2.0 License.
 
+## Component Versions
+
+| Component | Version |
+|-----------|---------|
+| DuckDB | v1.3.1 |
+| SQLite | 3.46.1 |
+| Apache Arrow (Flight SQL) | 20.0.0 |
+| jwt-cpp | v0.7.0 |
+
 ## Option 1 - Running from the published Docker image
 
 Open a terminal, then pull and run the published Docker image which has everything setup (change: "--detach" to "--interactive" if you wish to see the stdout on your screen) - with command:


### PR DESCRIPTION
## Summary
- document component versions for DuckDB, SQLite, Arrow and jwt-cpp

## Testing
- `pip install -r requirements.txt`
- `bash scripts/test_gizmosql.sh` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_685178644cd88327a0e16f1fbb05884c