### PR TITLE
Handle SIGINT for shutdown signals

### DIFF
--- a/src/library/gizmosql_library.cpp
+++ b/src/library/gizmosql_library.cpp
@@ -133,8 +133,8 @@ arrow::Result<std::shared_ptr<flight::sql::FlightSqlServerBase>> FlightSQLServer
   if (server != nullptr) {
     ARROW_CHECK_OK(server->Init(options));
 
-    // Exit with a clean error code (0) on SIGTERM
-    ARROW_CHECK_OK(server->SetShutdownOnSignals({SIGTERM}));
+    // Exit with a clean error code (0) on SIGTERM or SIGINT
+    ARROW_CHECK_OK(server->SetShutdownOnSignals({SIGTERM, SIGINT}));
 
     std::cout << "GizmoSQL server version: " << GIZMOSQL_SERVER_VERSION
               << " - with engine: " << db_type << " - will listen on "


### PR DESCRIPTION
## Summary
- respond to SIGINT in addition to SIGTERM for server shutdown

## Testing
- `cmake -S . -B build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr/local` *(fails: could not download zlib during Arrow build)*

------
https://chatgpt.com/codex/tasks/task_e_685abe9e3a348327be41db3a34795f8e