### PR TITLE
Move container entrypoints to "exec" form

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,4 +121,4 @@ EXPOSE 31337
 # Run a test to ensure that the server works...
 #RUN scripts/test_gizmosql.sh
 
-ENTRYPOINT scripts/start_gizmosql.sh
+ENTRYPOINT ["scripts/start_gizmosql.sh"]

--- a/Dockerfile-slim.ci
+++ b/Dockerfile-slim.ci
@@ -43,4 +43,4 @@ RUN chmod +x /usr/local/bin/gizmosql_client
 
 EXPOSE 31337
 
-ENTRYPOINT scripts/start_gizmosql_slim.sh
+ENTRYPOINT ["scripts/start_gizmosql_slim.sh"]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -112,4 +112,4 @@ EXPOSE 31337
 # Run a test to ensure that the server works...
 RUN scripts/test_gizmosql.sh
 
-ENTRYPOINT scripts/start_gizmosql.sh
+ENTRYPOINT ["scripts/start_gizmosql.sh"]

--- a/scripts/start_gizmosql.sh
+++ b/scripts/start_gizmosql.sh
@@ -39,7 +39,7 @@ then
   READONLY_FLAG="--readonly"
 fi
 
-gizmosql_server \
+exec gizmosql_server \
   --backend="${L_DATABASE_BACKEND}" \
   --database-filename="${L_DATABASE_FILENAME}" \
   ${TLS_ARG} \

--- a/scripts/start_gizmosql_slim.sh
+++ b/scripts/start_gizmosql_slim.sh
@@ -38,7 +38,7 @@ then
   READONLY_FLAG="--readonly"
 fi
 
-gizmosql_server \
+exec gizmosql_server \
   --backend="${L_DATABASE_BACKEND}" \
   --database-filename="${L_DATABASE_FILENAME}" \
   ${TLS_ARG} \


### PR DESCRIPTION
It is the preferred method per the docs here:
https://docs.docker.com/reference/dockerfile#entrypoint

I've also included an `exec` statement inside the scripts.

The need for this - when killing a pod in kubernetes, it sends a kill signal to the process with pid 1 - which is currently not gizmosql. k8s then has to wait for the 30 second grace period to end before forcably killing the container.

Using the `exec` form makes gizmosql be pid 1 inside the container so k8s can properly shut it down.