### PR TITLE
Remove dead GetInitSql() from TPCHBenchmarkFixture

### DIFF
--- a/tests/integration/test_tpch_benchmark.cpp
+++ b/tests/integration/test_tpch_benchmark.cpp
@@ -755,11 +755,6 @@ class TPCHBenchmarkFixture
         .password = "tpch_tester",
     };
   }
-
-  // Custom init SQL to generate TPC-H data
-  static std::string GetInitSql() {
-    return "INSTALL tpch; LOAD tpch; CALL dbgen(sf=1);";
-  }
 };
 
 // Static member definitions required by the template


### PR DESCRIPTION
Remove unused method - TPC-H tests generate data manually during test execution.

🤖 Generated with [Claude Code](https://claude.ai/code)