### PR TITLE
chore: Improve entrypoint scripts and documentation for environment v…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to GizmoSQL will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Docker entrypoint scripts now default to in-memory database when `DATABASE_FILENAME` is not set
+
+### Added
+
+- `GIZMOSQL_EXTRA_ARGS` env var for passing additional CLI flags to `gizmosql_server` in entrypoint scripts
+- `MTLS_CA_CERT_FILENAME` and `HEALTH_PORT` env vars in entrypoint scripts
+- `:memory:` as an explicit value for `DATABASE_FILENAME` to request in-memory mode
+- Comprehensive env var documentation in entrypoint script headers
+
 ## [1.16.1] - 2026-02-05
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,10 @@ Before committing any change, ensure you have completed ALL of the following:
 - [ ] For new CLI flags/options, document in both:
   - The relevant feature doc (e.g., `docs/token_authentication.md`)
   - The CLI help text in `src/gizmosql_server.cpp`
+- [ ] For new or changed environment variables, keep these in sync:
+  - `src/gizmosql_server.cpp` — native env var handling (`std::getenv` calls)
+  - `scripts/start_gizmosql.sh` and `scripts/start_gizmosql_slim.sh` — header comment env var tables
+  - The relevant feature doc in `docs/` (e.g., `docs/token_authentication.md`)
 - [ ] For library API changes, update docstrings in `src/common/include/gizmosql_library.h`
 
 ### 3. Changelog

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -69,7 +69,7 @@ docker run --name gizmosql \
            gizmodata/gizmosql:latest
 ```
 
-The above command will automatically mount a very small TPC-H DuckDB database file.
+The above command will start GizmoSQL with an in-memory DuckDB database. To use a persistent database file, set the `DATABASE_FILENAME` environment variable (see example below).
 
 **Note**: You can disable TLS in the container by setting environment variable: `TLS_ENABLED` to "0" (default is "1" - enabled).  This is not recommended unless you are using an mTLS sidecar in Kubernetes or something similar, as it will be insecure.    
 
@@ -389,7 +389,10 @@ GizmoSQL can be configured via environment variables or CLI flags. Below are the
 | health-check-query / GIZMOSQL_HEALTH_CHECK_QUERY | SQL query used for health checks | SELECT 1 | --health-check-query |
 | enable-instrumentation / GIZMOSQL_ENABLE_INSTRUMENTATION | *[Enterprise]* Enable session instrumentation | false | --enable-instrumentation |
 | instrumentation-db-path / GIZMOSQL_INSTRUMENTATION_DB_PATH | *[Enterprise]* Path for instrumentation database | (same dir as main DB) | --instrumentation-db-path |
+| instrumentation-catalog / GIZMOSQL_INSTRUMENTATION_CATALOG | *[Enterprise]* Pre-attached DuckLake catalog name for instrumentation | none | --instrumentation-catalog |
+| instrumentation-schema / GIZMOSQL_INSTRUMENTATION_SCHEMA | *[Enterprise]* Schema within the instrumentation catalog | main | --instrumentation-schema |
 | license-key-file / GIZMOSQL_LICENSE_KEY_FILE | *[Enterprise]* Path to license key file (JWT format) | none | --license-key-file, -L |
+| allow-cross-instance-tokens / GIZMOSQL_ALLOW_CROSS_INSTANCE_TOKENS | Accept tokens issued by other GizmoSQL instances sharing the same secret key | false | --allow-cross-instance-tokens |
 
 Notes and best practices:
 - Always set GIZMOSQL_PASSWORD in production.
@@ -484,11 +487,11 @@ To enhance security, never disable TLS in production unless behind a secured pro
 
 There is now a slim docker image available, without Python, tls certificate generation, sample database files, etc.   
 
-You must supply the following environment variables to the slim image:
-- `DATABASE_FILENAME` - the path to the database file to use
+You must supply the following environment variable to the slim image:
 - `GIZMOSQL_PASSWORD` - the password to use for the GizmoSQL server
 
 You can optionally supply the following environment variables:
+- `DATABASE_FILENAME` - the path to the database file to use (default: in-memory; set to `:memory:` explicitly for the same effect)
 - `TLS_ENABLED` - set to "1" to enable TLS (default is "0" - disabled)
 - `TLS_CERT` - If `TLS_ENABLED` is 1 - provide the path to the TLS certificate file (it must be mounted in the container)
 - `TLS_KEY` - If `TLS_ENABLED` is 1 - provide the path to the TLS key file (it must be mounted in the container)

--- a/scripts/start_gizmosql.sh
+++ b/scripts/start_gizmosql.sh
@@ -1,48 +1,108 @@
 #!/bin/bash
+#
+# Docker entrypoint for the full GizmoSQL image (with TLS cert generation).
+#
+# ── Script-managed env vars (mapped to CLI flags here) ──────────────────────
+#   DATABASE_BACKEND          --backend             (default: "duckdb")
+#   DATABASE_FILENAME         --database-filename   (default: "" = in-memory)
+#   TLS_ENABLED               generate & pass --tls (default: "1")
+#   PRINT_QUERIES             --print-queries       (default: "1")
+#   READONLY                  --readonly            (default: "0")
+#   QUERY_TIMEOUT             --query-timeout       (default: "0")
+#   MTLS_CA_CERT_FILENAME     --mtls-ca-cert-filename
+#   HEALTH_PORT               --health-port
+#
+# ── Passthrough env vars (read natively by gizmosql_server) ─────────────────
+#   GIZMOSQL_PASSWORD         --password
+#   GIZMOSQL_PORT             --port
+#   GIZMOSQL_USERNAME         --username
+#   SECRET_KEY                --secret-key
+#   INIT_SQL_COMMANDS         --init-sql-commands
+#   INIT_SQL_COMMANDS_FILE    --init-sql-commands-file
+#   GIZMOSQL_LOG_LEVEL        --log-level
+#   GIZMOSQL_LOG_FORMAT       --log-format
+#   GIZMOSQL_ACCESS_LOG       --access-log
+#   GIZMOSQL_LOG_FILE         --log-file
+#   GIZMOSQL_QUERY_LOG_LEVEL  --query-log-level
+#   GIZMOSQL_AUTH_LOG_LEVEL   --auth-log-level
+#   GIZMOSQL_HEALTH_CHECK_QUERY      --health-check-query
+#   GIZMOSQL_ENABLE_INSTRUMENTATION  --enable-instrumentation
+#   GIZMOSQL_INSTRUMENTATION_DB_PATH --instrumentation-db-path
+#   GIZMOSQL_INSTRUMENTATION_CATALOG --instrumentation-catalog
+#   GIZMOSQL_INSTRUMENTATION_SCHEMA  --instrumentation-schema
+#   GIZMOSQL_LICENSE_KEY_FILE        --license-key-file
+#   GIZMOSQL_ALLOW_CROSS_INSTANCE_TOKENS --allow-cross-instance-tokens
+#
+# ── Escape hatch ────────────────────────────────────────────────────────────
+#   GIZMOSQL_EXTRA_ARGS       Appended verbatim to the command line.
+#                             Supports quoted values, e.g.:
+#                             GIZMOSQL_EXTRA_ARGS='--init-sql-commands "CREATE TABLE t(id INT)"'
+#
+# ── Positional args (backward compat) ──────────────────────────────────────
+#   $1  DATABASE_BACKEND
+#   $2  DATABASE_FILENAME
+#   $3  TLS_ENABLED
+#   $4  PRINT_QUERIES
+#   $5  READONLY
+#   $6  QUERY_TIMEOUT
+#
 
 set -e
 
-SCRIPT_DIR=$(dirname ${0})
-TLS_DIR=${SCRIPT_DIR}/../tls
+SCRIPT_DIR=$(dirname "${0}")
+TLS_DIR="${SCRIPT_DIR}/../tls"
 
 L_DATABASE_BACKEND=${1:-${DATABASE_BACKEND:-"duckdb"}}
-L_DATABASE_FILENAME=${2:-${DATABASE_FILENAME:-"data/TPC-H-small.duckdb"}}
+L_DATABASE_FILENAME=${2:-${DATABASE_FILENAME:-""}}
 L_TLS_ENABLED=${3:-${TLS_ENABLED:-"1"}}
 L_PRINT_QUERIES=${4:-${PRINT_QUERIES:-"1"}}
 L_READONLY=${5:-${READONLY:-"0"}}
 L_QUERY_TIMEOUT=${6:-${QUERY_TIMEOUT:-"0"}}
 
-TLS_ARG=""
-if [ "${L_TLS_ENABLED}" == "1" ]
-then
-  pushd ${TLS_DIR}
-  if [ ! -f ./cert0.pem ]
-  then
-     echo -n "Generating TLS certs...\n"
-     ./gen-certs.sh
+# Treat ":memory:" as in-memory (empty string)
+if [ "${L_DATABASE_FILENAME}" = ":memory:" ]; then
+  L_DATABASE_FILENAME=""
+fi
+
+# ── Build argument array ────────────────────────────────────────────────────
+ARGS=()
+
+ARGS+=(--backend="${L_DATABASE_BACKEND}")
+ARGS+=(--database-filename="${L_DATABASE_FILENAME}")
+
+# TLS: generate self-signed certs if needed
+if [ "${L_TLS_ENABLED}" = "1" ]; then
+  pushd "${TLS_DIR}" > /dev/null
+  if [ ! -f ./cert0.pem ]; then
+    echo "Generating TLS certs..."
+    ./gen-certs.sh
   fi
-  TLS_ARG="--tls tls/cert0.pem tls/cert0.key"
-  popd
+  popd > /dev/null
+  ARGS+=(--tls tls/cert0.pem tls/cert0.key)
 fi
 
-# Setup the print_queries option
-PRINT_QUERIES_FLAG=""
-if [ "${L_PRINT_QUERIES}" == "1" ]
-then
-  PRINT_QUERIES_FLAG="--print-queries"
+if [ "${L_PRINT_QUERIES}" = "1" ]; then
+  ARGS+=(--print-queries)
 fi
 
-# Setup the readonly option
-READONLY_FLAG=""
-if [ "${L_READONLY}" == "1" ]
-then
-  READONLY_FLAG="--readonly"
+if [ "${L_READONLY}" = "1" ]; then
+  ARGS+=(--readonly)
 fi
 
-exec gizmosql_server \
-  --backend="${L_DATABASE_BACKEND}" \
-  --database-filename="${L_DATABASE_FILENAME}" \
-  ${TLS_ARG} \
-  ${PRINT_QUERIES_FLAG} \
-  ${READONLY_FLAG} \
-  --query-timeout ${L_QUERY_TIMEOUT}
+ARGS+=(--query-timeout "${L_QUERY_TIMEOUT}")
+
+if [ -n "${MTLS_CA_CERT_FILENAME}" ]; then
+  ARGS+=(--mtls-ca-cert-filename "${MTLS_CA_CERT_FILENAME}")
+fi
+
+if [ -n "${HEALTH_PORT}" ]; then
+  ARGS+=(--health-port "${HEALTH_PORT}")
+fi
+
+# ── Extra args escape hatch ─────────────────────────────────────────────────
+if [ -n "${GIZMOSQL_EXTRA_ARGS}" ]; then
+  eval "EXTRA=(${GIZMOSQL_EXTRA_ARGS})"
+  ARGS+=("${EXTRA[@]}")
+fi
+
+exec gizmosql_server "${ARGS[@]}"

--- a/scripts/start_gizmosql_slim.sh
+++ b/scripts/start_gizmosql_slim.sh
@@ -1,8 +1,60 @@
 #!/bin/bash
+#
+# Docker entrypoint for the slim GizmoSQL image (no TLS cert generation).
+# TLS certs must be provided externally via TLS_CERT / TLS_KEY.
+#
+# ── Script-managed env vars (mapped to CLI flags here) ──────────────────────
+#   DATABASE_FILENAME         --database-filename   (default: "" = in-memory)
+#   DATABASE_BACKEND          --backend             (default: "duckdb")
+#   PRINT_QUERIES             --print-queries       (default: "1")
+#   TLS_ENABLED               --tls with TLS_CERT/TLS_KEY (default: "0")
+#   TLS_CERT                  cert path for --tls
+#   TLS_KEY                   key  path for --tls
+#   READONLY                  --readonly            (default: "0")
+#   QUERY_TIMEOUT             --query-timeout       (default: "0")
+#   MTLS_CA_CERT_FILENAME     --mtls-ca-cert-filename
+#   HEALTH_PORT               --health-port
+#
+# ── Passthrough env vars (read natively by gizmosql_server) ─────────────────
+#   GIZMOSQL_PASSWORD         --password
+#   GIZMOSQL_PORT             --port
+#   GIZMOSQL_USERNAME         --username
+#   SECRET_KEY                --secret-key
+#   INIT_SQL_COMMANDS         --init-sql-commands
+#   INIT_SQL_COMMANDS_FILE    --init-sql-commands-file
+#   GIZMOSQL_LOG_LEVEL        --log-level
+#   GIZMOSQL_LOG_FORMAT       --log-format
+#   GIZMOSQL_ACCESS_LOG       --access-log
+#   GIZMOSQL_LOG_FILE         --log-file
+#   GIZMOSQL_QUERY_LOG_LEVEL  --query-log-level
+#   GIZMOSQL_AUTH_LOG_LEVEL   --auth-log-level
+#   GIZMOSQL_HEALTH_CHECK_QUERY      --health-check-query
+#   GIZMOSQL_ENABLE_INSTRUMENTATION  --enable-instrumentation
+#   GIZMOSQL_INSTRUMENTATION_DB_PATH --instrumentation-db-path
+#   GIZMOSQL_INSTRUMENTATION_CATALOG --instrumentation-catalog
+#   GIZMOSQL_INSTRUMENTATION_SCHEMA  --instrumentation-schema
+#   GIZMOSQL_LICENSE_KEY_FILE        --license-key-file
+#   GIZMOSQL_ALLOW_CROSS_INSTANCE_TOKENS --allow-cross-instance-tokens
+#
+# ── Escape hatch ────────────────────────────────────────────────────────────
+#   GIZMOSQL_EXTRA_ARGS       Appended verbatim to the command line.
+#                             Supports quoted values, e.g.:
+#                             GIZMOSQL_EXTRA_ARGS='--init-sql-commands "CREATE TABLE t(id INT)"'
+#
+# ── Positional args (backward compat) ──────────────────────────────────────
+#   $1  DATABASE_FILENAME
+#   $2  DATABASE_BACKEND
+#   $3  PRINT_QUERIES
+#   $4  TLS_ENABLED
+#   $5  TLS_CERT
+#   $6  TLS_KEY
+#   $7  READONLY
+#   $8  QUERY_TIMEOUT
+#
 
 set -e
 
-L_DATABASE_FILENAME=${1:-${DATABASE_FILENAME?"You must specify a database filename."}}
+L_DATABASE_FILENAME=${1:-${DATABASE_FILENAME:-""}}
 L_DATABASE_BACKEND=${2:-${DATABASE_BACKEND:-"duckdb"}}
 L_PRINT_QUERIES=${3:-${PRINT_QUERIES:-"1"}}
 L_TLS_ENABLED=${4:-${TLS_ENABLED:-"0"}}
@@ -11,37 +63,48 @@ L_TLS_KEY=${6:-${TLS_KEY}}
 L_READONLY=${7:-${READONLY:-"0"}}
 L_QUERY_TIMEOUT=${8:-${QUERY_TIMEOUT:-"0"}}
 
-TLS_ARG=""
-if [ "${L_TLS_ENABLED}" == "1" ]
-then
-  # Make sure L_TLS_CERT and L_TLS_KEY were provided
-  if [ -z "${L_TLS_CERT}" ] || [ -z "${L_TLS_KEY}" ]
-  then
-    echo "TLS_CERT and TLS_KEY must be passed when TLS is enabled."
+# Treat ":memory:" as in-memory (empty string)
+if [ "${L_DATABASE_FILENAME}" = ":memory:" ]; then
+  L_DATABASE_FILENAME=""
+fi
+
+# ── Build argument array ────────────────────────────────────────────────────
+ARGS=()
+
+ARGS+=(--backend="${L_DATABASE_BACKEND}")
+ARGS+=(--database-filename="${L_DATABASE_FILENAME}")
+
+# TLS: require cert and key when enabled
+if [ "${L_TLS_ENABLED}" = "1" ]; then
+  if [ -z "${L_TLS_CERT}" ] || [ -z "${L_TLS_KEY}" ]; then
+    echo "TLS_CERT and TLS_KEY must be passed when TLS is enabled." >&2
     exit 1
   fi
-
-  TLS_ARG="--tls ${L_TLS_CERT} ${L_TLS_KEY}"
+  ARGS+=(--tls "${L_TLS_CERT}" "${L_TLS_KEY}")
 fi
 
-# Setup the print_queries option
-PRINT_QUERIES_FLAG=""
-if [ "${L_PRINT_QUERIES}" == "1" ]
-then
-  PRINT_QUERIES_FLAG="--print-queries"
+if [ "${L_PRINT_QUERIES}" = "1" ]; then
+  ARGS+=(--print-queries)
 fi
 
-# Setup the readonly option
-READONLY_FLAG=""
-if [ "${L_READONLY}" == "1" ]
-then
-  READONLY_FLAG="--readonly"
+if [ "${L_READONLY}" = "1" ]; then
+  ARGS+=(--readonly)
 fi
 
-exec gizmosql_server \
-  --backend="${L_DATABASE_BACKEND}" \
-  --database-filename="${L_DATABASE_FILENAME}" \
-  ${TLS_ARG} \
-  ${PRINT_QUERIES_FLAG} \
-  ${READONLY_FLAG} \
-  --query-timeout ${L_QUERY_TIMEOUT}
+ARGS+=(--query-timeout "${L_QUERY_TIMEOUT}")
+
+if [ -n "${MTLS_CA_CERT_FILENAME}" ]; then
+  ARGS+=(--mtls-ca-cert-filename "${MTLS_CA_CERT_FILENAME}")
+fi
+
+if [ -n "${HEALTH_PORT}" ]; then
+  ARGS+=(--health-port "${HEALTH_PORT}")
+fi
+
+# ── Extra args escape hatch ─────────────────────────────────────────────────
+if [ -n "${GIZMOSQL_EXTRA_ARGS}" ]; then
+  eval "EXTRA=(${GIZMOSQL_EXTRA_ARGS})"
+  ARGS+=("${EXTRA[@]}")
+fi
+
+exec gizmosql_server "${ARGS[@]}"

--- a/scripts/test_gizmosql.sh
+++ b/scripts/test_gizmosql.sh
@@ -6,6 +6,9 @@ TLS_DIR=${SCRIPT_DIR}/../tls
 # Set a dummy password for the test...
 export GIZMOSQL_PASSWORD="testing123"
 
+# Use the TPC-H sample database (entrypoint defaults to in-memory)
+export DATABASE_FILENAME="data/TPC-H-small.duckdb"
+
 # Start the Flight SQL Server - in the background...
 ${SCRIPT_DIR}/start_gizmosql.sh &
 

--- a/src/common/gizmosql_library.cpp
+++ b/src/common/gizmosql_library.cpp
@@ -608,7 +608,7 @@ arrow::Result<std::shared_ptr<flight::sql::FlightSqlServerBase>> CreateFlightSQL
     std::string instrumentation_schema,
     const bool& allow_cross_instance_tokens) {
   // Validate and default the arguments to env var values where applicable
-  if (database_filename.empty()) {
+  if (database_filename.empty() || database_filename == ":memory:") {
     GIZMOSQL_LOG(INFO)
         << "WARNING - The database filename was not provided, opening an in-memory "
            "database...";


### PR DESCRIPTION
…ariables

- Default to in-memory database when `DATABASE_FILENAME` is unset or explicitly set to `:memory:`
- Add `GIZMOSQL_EXTRA_ARGS`, `MTLS_CA_CERT_FILENAME`, and `HEALTH_PORT` environment variables in entrypoint scripts
- Enhance entrypoint script headers with comprehensive env var documentation
- Update `CLAUDE.md`, `CHANGELOG.md`, and main documentation for new additions