### PR TITLE
feat: Dynamic terminal width for interactive output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Dynamic terminal width** (`gizmosql_client`): Output width now automatically adapts when the terminal window is resized — each query re-reads the terminal dimensions before rendering. Explicit `.maxwidth N` overrides auto-detection; `.maxwidth 0` re-enables it.
+
 ## [1.18.0] - 2026-02-17
 
 ### Added

--- a/src/client/client_config.hpp
+++ b/src/client/client_config.hpp
@@ -83,6 +83,7 @@ struct ClientConfig {
   std::string insert_table = "table";
   int max_rows = 0;
   int max_width = 0;
+  bool auto_width = false;  // When true, re-read terminal width before each render
 
   // Runtime
   bool is_interactive = false;

--- a/src/client/command_processor.cpp
+++ b/src/client/command_processor.cpp
@@ -339,8 +339,10 @@ CommandResult CommandProcessor::Process(const std::string& line) {
         int val = std::stoi(args[1]);
         if (val == 0) {
           config_.max_width = GetTerminalWidth();
+          config_.auto_width = true;
         } else {
           config_.max_width = val;
+          config_.auto_width = false;
         }
       } catch (...) {
         std::cerr << "Error: invalid number '" << args[1] << "'" << std::endl;

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -231,6 +231,7 @@ int main(int argc, char** argv) {
   if (config.is_interactive && !config.output_file.has_value()) {
     config.max_rows = 40;
     config.max_width = GetTerminalWidth();
+    config.auto_width = true;
   }
 
   // Set up output file redirect

--- a/src/client/shell_loop.cpp
+++ b/src/client/shell_loop.cpp
@@ -84,6 +84,11 @@ bool ExecuteStatement(FlightConnection& conn, ClientConfig& config,
       auto ms =
           std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
 
+      // Re-read terminal width if in auto-width mode (tracks window resizes)
+      if (config.auto_width) {
+        config.max_width = GetTerminalWidth();
+      }
+
       auto renderer = CreateRenderer(config.output_mode, config);
       auto render_result = renderer->Render(**result, *config.output_stream);
 


### PR DESCRIPTION
## Summary
- Output width now automatically adapts when the terminal window is resized — each query re-reads terminal dimensions before rendering
- Explicit `.maxwidth N` overrides auto-detection; `.maxwidth 0` re-enables it
- Mirrors DuckDB CLI behavior

## Test plan
- [x] All 64 client shell integration tests pass locally
- [x] Verified auto-width updates on terminal resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)