### PR TITLE
Fix vcpkg cache: dynamic key and skip install on hit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,11 +420,12 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.VCPKG_ROOT }}/installed
-          key: vcpkg-x64-windows-static-boost-zlib-openssl-v1
+          key: vcpkg-x64-windows-static-${{ hashFiles('.github/workflows/ci.yml') }}
           restore-keys: |
-            vcpkg-x64-windows-static-boost-zlib-openssl-
+            vcpkg-x64-windows-static-
 
       - name: Install vcpkg dependencies
+        if: steps.vcpkg-cache.outputs.cache-hit != 'true'
         run: |
           & "$env:VCPKG_ROOT\vcpkg.exe" install boost-program-options boost-algorithm boost-uuid zlib openssl --triplet x64-windows-static --clean-after-build --x-install-root="$env:VCPKG_ROOT\installed"
 
@@ -433,7 +434,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ${{ env.VCPKG_ROOT }}/installed
-          key: vcpkg-x64-windows-static-boost-zlib-openssl-v1
+          key: vcpkg-x64-windows-static-${{ hashFiles('.github/workflows/ci.yml') }}
 
       - name: Setup MSVC
         uses: ilammy/msvc-dev-cmd@v1


### PR DESCRIPTION
## Summary
- Cache key was pinned with a static suffix requiring manual bumping when dependencies change. Now uses hashFiles so the key auto-invalidates when the workflow changes.
- vcpkg install ran unconditionally even on cache hit, recalculating ABI hashes and rebuilding packages when the runner vcpkg version updates. Now skipped when cache-hit is true.

## Test plan
- Verify Windows build job uses cached vcpkg packages (check Restore vcpkg cache step for cache hit)
- Verify cache key includes workflow file hash

Generated with Claude Code