### PR TITLE
Add --oauth-instance-id for multi-instance proxy routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Multi-instance OAuth proxy routing** (`--oauth-instance-id` / `GIZMOSQL_OAUTH_INSTANCE_ID`): Optional instance identifier that is embedded in the OAuth `state` parameter as `<instance-id>.<session-hash>`. This allows a shared OAuth callback proxy to extract the instance ID from the state and route the callback to the correct GizmoSQL server, enabling a single registered redirect URI (e.g., `https://oauth.example.com/oauth/callback`) to serve many dynamically provisioned instances. Fully backward-compatible — when unset, behavior is identical to before.
+
 ### Fixed
 
 - **Authentication log level misreporting severity**: When `--auth-log-level` was set to a level like `error`, successful authentication messages were logged with ERROR severity instead of INFO. The auth log level now acts as a visibility threshold — success messages always display at INFO severity, and the auth log level controls whether they appear at all ([#136](https://github.com/gizmodata/gizmosql/issues/136)).

--- a/docs/oauth_sso_setup.md
+++ b/docs/oauth_sso_setup.md
@@ -313,6 +313,7 @@ export GIZMOSQL_OAUTH_CLIENT_ID="your-client-id"
 export GIZMOSQL_OAUTH_CLIENT_SECRET="your-client-secret"
 export GIZMOSQL_OAUTH_PORT="31339"
 # export GIZMOSQL_OAUTH_BASE_URL="https://my-proxy:443"  # Override base URL when behind a reverse proxy
+# export GIZMOSQL_OAUTH_INSTANCE_ID="my-instance-uuid"  # For multi-instance OAuth proxy routing
 # export GIZMOSQL_OAUTH_DISABLE_TLS="true"  # WARNING: localhost development only
 export GIZMOSQL_TOKEN_ALLOWED_ISSUER="https://your-idp.com"
 export GIZMOSQL_TOKEN_ALLOWED_AUDIENCE="your-client-id"

--- a/docs/token_authentication.md
+++ b/docs/token_authentication.md
@@ -437,6 +437,7 @@ Server-side OAuth code exchange simplifies client configuration by making the Gi
 | `--oauth-scopes` | `GIZMOSQL_OAUTH_SCOPES` | `openid profile email` | OAuth scopes to request. |
 | `--oauth-port` | `GIZMOSQL_OAUTH_PORT` | `31339` | Port for the OAuth HTTP(S) server. |
 | `--oauth-base-url` | `GIZMOSQL_OAUTH_BASE_URL` | auto-constructed | Override the base URL for the OAuth server (e.g., `https://my-proxy:443`). Redirect URI and discovery URL are derived from this. |
+| `--oauth-instance-id` | `GIZMOSQL_OAUTH_INSTANCE_ID` | *(empty)* | Instance identifier embedded in the OAuth `state` parameter for multi-instance proxy routing. When set, state becomes `<instance-id>.<session-hash>`, allowing a shared callback proxy to extract the instance ID and route to the correct server. |
 | `--oauth-disable-tls` | `GIZMOSQL_OAUTH_DISABLE_TLS` | `false` | Disable TLS on the OAuth callback server. **WARNING: localhost only.** |
 
 The OAuth server **requires** `--token-allowed-issuer` and `--token-allowed-audience` to be set. OIDC endpoints (authorization, token, JWKS) are auto-discovered from the issuer.

--- a/scripts/start_gizmosql.sh
+++ b/scripts/start_gizmosql.sh
@@ -40,6 +40,7 @@
 #   GIZMOSQL_OAUTH_SCOPES                --oauth-scopes
 #   GIZMOSQL_OAUTH_PORT                  --oauth-port
 #   GIZMOSQL_OAUTH_BASE_URL              --oauth-base-url
+#   GIZMOSQL_OAUTH_INSTANCE_ID           --oauth-instance-id
 #   GIZMOSQL_OAUTH_DISABLE_TLS           --oauth-disable-tls (localhost only!)
 #
 # ── Escape hatch ────────────────────────────────────────────────────────────

--- a/scripts/start_gizmosql_slim.sh
+++ b/scripts/start_gizmosql_slim.sh
@@ -43,6 +43,7 @@
 #   GIZMOSQL_OAUTH_SCOPES                --oauth-scopes
 #   GIZMOSQL_OAUTH_PORT                  --oauth-port
 #   GIZMOSQL_OAUTH_BASE_URL              --oauth-base-url
+#   GIZMOSQL_OAUTH_INSTANCE_ID           --oauth-instance-id
 #   GIZMOSQL_OAUTH_DISABLE_TLS           --oauth-disable-tls (localhost only!)
 #
 # ── Escape hatch ────────────────────────────────────────────────────────────

--- a/src/common/gizmosql_library.cpp
+++ b/src/common/gizmosql_library.cpp
@@ -432,6 +432,7 @@ arrow::Result<std::shared_ptr<flight::sql::FlightSqlServerBase>> FlightSQLServer
     const std::string& oauth_scopes,
     const int& oauth_port,
     const std::string& oauth_base_url,
+    const std::string& oauth_instance_id,
     const bool& oauth_disable_tls,
     const bool& telemetry_enabled) {
   ARROW_ASSIGN_OR_RAISE(auto location,
@@ -571,6 +572,7 @@ arrow::Result<std::shared_ptr<flight::sql::FlightSqlServerBase>> FlightSQLServer
         .scopes = oauth_scopes,
         .redirect_uri = derived_redirect_uri,
         .secret_key = secret_key,
+        .instance_id = oauth_instance_id,
         .authorized_email_patterns = email_patterns,
         .disable_tls = oauth_disable_tls,
         .tls_cert_path = tls_cert_path.string(),
@@ -891,6 +893,7 @@ arrow::Result<std::shared_ptr<flight::sql::FlightSqlServerBase>> CreateFlightSQL
     std::string oauth_scopes,
     int oauth_port,
     std::string oauth_base_url,
+    std::string oauth_instance_id,
     const bool& oauth_disable_tls,
     const bool& telemetry_enabled) {
   // Validate and default the arguments to env var values where applicable
@@ -1136,6 +1139,9 @@ arrow::Result<std::shared_ptr<flight::sql::FlightSqlServerBase>> CreateFlightSQL
   if (oauth_base_url.empty()) {
     oauth_base_url = SafeGetEnvVarValue("GIZMOSQL_OAUTH_BASE_URL");
   }
+  if (oauth_instance_id.empty()) {
+    oauth_instance_id = SafeGetEnvVarValue("GIZMOSQL_OAUTH_INSTANCE_ID");
+  }
 
   // Validate OAuth configuration
   if (!oauth_client_id.empty()) {
@@ -1158,7 +1164,7 @@ arrow::Result<std::shared_ptr<flight::sql::FlightSqlServerBase>> CreateFlightSQL
       enable_instrumentation, instrumentation_db_path,
       instrumentation_catalog, instrumentation_schema, allow_cross_instance_tokens,
       oauth_client_id, oauth_client_secret, oauth_scopes, oauth_port, oauth_base_url,
-      oauth_disable_tls, telemetry_enabled);
+      oauth_instance_id, oauth_disable_tls, telemetry_enabled);
 }
 
 arrow::Status StartFlightSQLServer(
@@ -1222,6 +1228,7 @@ int RunFlightSQLServer(const BackendType backend, fs::path database_filename,
                        std::string oauth_scopes,
                        int oauth_port,
                        std::string oauth_base_url,
+                       std::string oauth_instance_id,
                        std::optional<bool> oauth_disable_tls,
                        std::optional<bool> otel_enabled, std::string otel_exporter,
                        std::string otel_endpoint, std::string otel_service_name,
@@ -1383,7 +1390,7 @@ int RunFlightSQLServer(const BackendType backend, fs::path database_filename,
       enable_instrumentation.value(), instrumentation_db_path,
       instrumentation_catalog, instrumentation_schema, allow_cross_instance_tokens.value(),
       oauth_client_id, oauth_client_secret, oauth_scopes, oauth_port, oauth_base_url,
-      oauth_disable_tls.value(), telemetry_enabled);
+      oauth_instance_id, oauth_disable_tls.value(), telemetry_enabled);
 
   if (create_server_result.ok()) {
     auto server_ptr = create_server_result.ValueOrDie();

--- a/src/common/include/gizmosql_library.h
+++ b/src/common/include/gizmosql_library.h
@@ -130,6 +130,7 @@ int RunFlightSQLServer(
     std::string oauth_scopes = "",
     int oauth_port = 0,
     std::string oauth_base_url = "",
+    std::string oauth_instance_id = "",
     std::optional<bool> oauth_disable_tls = std::nullopt,
     std::optional<bool> otel_enabled = std::nullopt, std::string otel_exporter = "",
     std::string otel_endpoint = "", std::string otel_service_name = "",

--- a/src/enterprise/oauth/oauth_http_server.cpp
+++ b/src/enterprise/oauth/oauth_http_server.cpp
@@ -69,7 +69,8 @@ arrow::Status OAuthHttpServer::Start() {
 
   if (config_.disable_tls) {
     GIZMOSQL_LOG(WARNING) << "OAuth HTTP server TLS is DISABLED. "
-                          << "This should ONLY be used for localhost development/testing.";
+                          << "This is expected when behind a TLS-terminating reverse proxy, "
+                          << "but should NOT be used for direct internet-facing deployments.";
   }
 
   // Create server (SSL if TLS configured and not disabled)
@@ -160,7 +161,13 @@ void OAuthHttpServer::HandleInitiate(const httplib::Request& req, httplib::Respo
   auth_url += "&client_id=" + UrlEncode(config_.client_id);
   auth_url += "&redirect_uri=" + UrlEncode(config_.redirect_uri);
   auth_url += "&scope=" + UrlEncode(config_.scopes);
-  auth_url += "&state=" + session_hash;
+
+  // Embed instance_id in state for multi-instance proxy routing (optional)
+  std::string state_value = session_hash;
+  if (!config_.instance_id.empty()) {
+    state_value = config_.instance_id + "." + session_hash;
+  }
+  auth_url += "&state=" + UrlEncode(state_value);
 
   GIZMOSQL_LOG(DEBUG) << "OAuth: Initiated session for UUID: "
                       << uuid.substr(0, 8) << "...";
@@ -202,7 +209,13 @@ void OAuthHttpServer::HandleStart(const httplib::Request& req, httplib::Response
   auth_url += "&client_id=" + UrlEncode(config_.client_id);
   auth_url += "&redirect_uri=" + UrlEncode(config_.redirect_uri);
   auth_url += "&scope=" + UrlEncode(config_.scopes);
-  auth_url += "&state=" + session_hash;
+
+  // Embed instance_id in state for multi-instance proxy routing (optional)
+  std::string state_value = session_hash;
+  if (!config_.instance_id.empty()) {
+    state_value = config_.instance_id + "." + session_hash;
+  }
+  auth_url += "&state=" + UrlEncode(state_value);
 
   GIZMOSQL_LOG(DEBUG) << "OAuth: Redirecting to IdP for session hash: "
                       << session_hash.substr(0, 8) << "...";
@@ -217,6 +230,17 @@ void OAuthHttpServer::HandleCallback(const httplib::Request& req, httplib::Respo
   auto state_it = req.params.find("state");
   auto error_it = req.params.find("error");
 
+  // Helper: strip instance_id prefix from state to recover the session hash
+  auto strip_instance_prefix = [this](const std::string& state) -> std::string {
+    if (!config_.instance_id.empty()) {
+      std::string prefix = config_.instance_id + ".";
+      if (state.size() > prefix.size() && state.compare(0, prefix.size(), prefix) == 0) {
+        return state.substr(prefix.size());
+      }
+    }
+    return state;
+  };
+
   // Check for IdP-reported error
   if (error_it != req.params.end()) {
     std::string error_desc;
@@ -230,8 +254,9 @@ void OAuthHttpServer::HandleCallback(const httplib::Request& req, httplib::Respo
     GIZMOSQL_LOG(WARNING) << "OAuth: IdP returned error: " << error_desc;
 
     if (state_it != req.params.end()) {
+      std::string err_session_hash = strip_instance_prefix(state_it->second);
       std::lock_guard<std::mutex> lock(pending_mutex_);
-      auto it = pending_auths_.find(state_it->second);
+      auto it = pending_auths_.find(err_session_hash);
       if (it != pending_auths_.end()) {
         it->second.error = error_desc;
       }
@@ -248,7 +273,7 @@ void OAuthHttpServer::HandleCallback(const httplib::Request& req, httplib::Respo
   }
 
   const std::string& code = code_it->second;
-  const std::string& session_hash = state_it->second;
+  const std::string session_hash = strip_instance_prefix(state_it->second);
 
   // Verify the session hash exists and is still pending
   {

--- a/src/enterprise/oauth/oauth_http_server.h
+++ b/src/enterprise/oauth/oauth_http_server.h
@@ -47,6 +47,7 @@ class OAuthHttpServer {
     std::string scopes;
     std::string redirect_uri;  // Auto-constructed if empty
     std::string secret_key;    // For HMAC session hashing only
+    std::string instance_id;   // Optional: embedded in state for multi-instance proxy routing
     std::vector<std::string> authorized_email_patterns;
     bool disable_tls = false;    // Run plain HTTP even when main server has TLS
     std::string tls_cert_path;

--- a/src/gizmosql_server.cpp
+++ b/src/gizmosql_server.cpp
@@ -149,9 +149,15 @@ int main(int argc, char** argv) {
               "Auto-constructed from scheme + localhost + oauth-port if empty. "
               "Use this when the server is behind a reverse proxy or accessed remotely. "
               "If not set, uses env var GIZMOSQL_OAUTH_BASE_URL.")
+            ("oauth-instance-id", po::value<std::string>()->default_value(""),
+              "[Enterprise] Instance identifier embedded in the OAuth state parameter for multi-instance "
+              "proxy routing. When set, the state sent to the IdP becomes '<instance-id>.<session-hash>', "
+              "allowing a shared OAuth callback proxy to extract the instance ID and route to the correct server. "
+              "If not set, uses env var GIZMOSQL_OAUTH_INSTANCE_ID.")
             ("oauth-disable-tls", po::value<bool>()->default_value(false),
               "[Enterprise] Disable TLS on the OAuth callback server even when the main server uses TLS. "
-              "WARNING: This should ONLY be used for localhost development/testing. "
+              "This is expected when behind a TLS-terminating reverse proxy (e.g., NGINX ingress), "
+              "but should NOT be used for direct internet-facing deployments. "
               "If not set, uses env var GIZMOSQL_OAUTH_DISABLE_TLS (1/true to enable).")
             // -------- OpenTelemetry controls --------
             ("otel-enabled", po::value<bool>()->default_value(false),
@@ -329,6 +335,9 @@ int main(int argc, char** argv) {
   std::string oauth_base_url =
       vm.count("oauth-base-url") ? vm["oauth-base-url"].as<std::string>() : "";
 
+  std::string oauth_instance_id =
+      vm.count("oauth-instance-id") ? vm["oauth-instance-id"].as<std::string>() : "";
+
   std::optional<bool> oauth_disable_tls =
       vm["oauth-disable-tls"].defaulted() ? std::nullopt
                                           : std::optional(vm["oauth-disable-tls"].as<bool>());
@@ -356,6 +365,6 @@ int main(int argc, char** argv) {
       health_check_query, enable_instrumentation, instrumentation_db_path,
       instrumentation_catalog, instrumentation_schema, license_key_file,
       allow_cross_instance_tokens, oauth_client_id, oauth_client_secret, oauth_scopes,
-      oauth_port, oauth_base_url, oauth_disable_tls, otel_enabled, otel_exporter,
+      oauth_port, oauth_base_url, oauth_instance_id, oauth_disable_tls, otel_enabled, otel_exporter,
       otel_endpoint, otel_service_name, otel_headers);
 }

--- a/tests/integration/test_oauth_server.cpp
+++ b/tests/integration/test_oauth_server.cpp
@@ -397,6 +397,7 @@ class OAuthServerTest : public ::testing::Test {
         /*oauth_scopes=*/"openid profile email",
         /*oauth_port=*/kOAuthTestPort,
         /*oauth_base_url=*/"",
+        /*oauth_instance_id=*/"",
         /*oauth_disable_tls=*/false);
 
     ASSERT_TRUE(result.ok()) << "Failed to create server: " << result.status().ToString();

--- a/tests/integration/test_server_fixture.h
+++ b/tests/integration/test_server_fixture.h
@@ -100,6 +100,7 @@ struct TestServerConfig {
   std::string oauth_scopes = "";                // OAuth scopes
   int oauth_port = 0;                           // OAuth HTTP server port
   std::string oauth_base_url = "";              // OAuth base URL override (derives redirect URI + discovery URL)
+  std::string oauth_instance_id = "";           // Instance ID for multi-instance OAuth proxy routing
   bool oauth_disable_tls = false;               // Disable TLS on OAuth callback server
 };
 
@@ -195,6 +196,7 @@ class ServerTestFixture : public ::testing::Test {
         /*oauth_scopes=*/config_.oauth_scopes,
         /*oauth_port=*/config_.oauth_port,
         /*oauth_base_url=*/config_.oauth_base_url,
+        /*oauth_instance_id=*/config_.oauth_instance_id,
         /*oauth_disable_tls=*/config_.oauth_disable_tls);
 
     ASSERT_TRUE(result.ok()) << "Failed to create server: " << result.status().ToString();


### PR DESCRIPTION
## Summary

- Adds `--oauth-instance-id` / `GIZMOSQL_OAUTH_INSTANCE_ID` — an optional instance identifier embedded in the OAuth `state` parameter as `<instance-id>.<session-hash>`
- Enables a shared OAuth callback proxy to extract the instance ID from the state and route the callback to the correct GizmoSQL server
- Allows a single registered redirect URI (e.g., `https://oauth.example.com/oauth/callback`) to serve many dynamically provisioned instances — required by strict OAuth providers like Google that do not support wildcard redirect URIs
- Updated `--oauth-disable-tls` help text to acknowledge legitimate reverse proxy use case (not just localhost dev)
- Fully backward-compatible: when `oauth_instance_id` is unset, behavior is identical to before

## Files changed

| File | Change |
|------|--------|
| `oauth_http_server.h` | Added `instance_id` to `Config` struct |
| `oauth_http_server.cpp` | Prepend instance_id to state in `HandleInitiate`/`HandleStart`; strip prefix in `HandleCallback` |
| `gizmosql_library.h` | Added `oauth_instance_id` param to `RunFlightSQLServer()` |
| `gizmosql_library.cpp` | Thread param through `RunFlightSQLServer` → `CreateFlightSQLServer` → `FlightSQLServerBuilder` → `OAuthHttpServer::Config` |
| `gizmosql_server.cpp` | Added `--oauth-instance-id` CLI option |
| `test_server_fixture.h` | Added `oauth_instance_id` to `TestServerConfig` |
| Scripts & docs | Updated env var tables and documentation |
| `CHANGELOG.md` | Added entry under `[Unreleased]` |

## Test plan

- [ ] Existing OAuth integration tests pass (no instance_id set → unchanged behavior)
- [ ] Manual test with `--oauth-instance-id=test123`: verify state parameter is `test123.<hmac-hash>`
- [ ] Manual test callback with prefixed state: verify session lookup succeeds after stripping
- [ ] Verify `GIZMOSQL_OAUTH_INSTANCE_ID` env var fallback works when CLI flag not provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)