### PR TITLE
Fix query/auth log level severity vs visibility threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Query and auth log levels now act as visibility thresholds**: When `--query-log-level` or `--auth-log-level` is set to `error`, routine INFO-level messages (e.g., "SQL command execution succeeded", "Successfully authenticated") are now properly suppressed instead of being promoted to ERROR severity. The component log level controls whether a message appears at all; the display severity always reflects the message's true nature ([#136](https://github.com/gizmodata/gizmosql/issues/136)).
+
 ## [1.19.1] - 2026-03-09
 
 ### Added

--- a/src/common/include/detail/gizmosql_logging.h
+++ b/src/common/include/detail/gizmosql_logging.h
@@ -245,13 +245,17 @@ ScopeGuard<F> MakeScopeGuard(F f) {
   } while (0)
 
 // Dynamic-level logging with separate threshold and display severity.
-// THRESHOLD controls whether the message is emitted (visibility gate).
-// DISPLAY_SEV controls the severity label shown in the log output.
+// THRESHOLD is the component's minimum level (e.g., query_log_level).
+// DISPLAY_SEV is the message's natural severity (e.g., INFO for routine logs).
+// The message is emitted only when DISPLAY_SEV >= both the component THRESHOLD
+// and the overall logger severity, ensuring that setting a component threshold
+// to ERROR suppresses INFO-level messages rather than promoting them to ERROR.
 #define GIZMOSQL_LOGKV_DYNAMIC_AT(THRESHOLD, DISPLAY_SEV, MSG, ...)      \
   do {                                                                   \
     auto _logger_sp = ::arrow::util::LoggerRegistry::GetDefaultLogger(); \
     auto* _logger = _logger_sp.get();                                    \
-    if (_logger && (THRESHOLD >= _logger->severity_threshold())) {       \
+    if (_logger && (DISPLAY_SEV >= THRESHOLD) &&                         \
+        (DISPLAY_SEV >= _logger->severity_threshold())) {                \
       ::gizmosql::LogWithFields(DISPLAY_SEV, __FILE__, __LINE__, MSG,    \
                                 ::gizmosql::FieldList{__VA_ARGS__});     \
     }                                                                    \
@@ -277,15 +281,23 @@ ScopeGuard<F> MakeScopeGuard(F f) {
 #define GIZMOSQL_LOGKV_SESSION(SEV, SESSION, MSG, ...) \
     GIZMOSQL_LOGKV(SEV, MSG, SESSION_KV_FIELDS(SESSION), __VA_ARGS__)
 
-// Session-aware dynamic-level logging variant
-#define GIZMOSQL_LOGKV_SESSION_DYNAMIC(SEV, SESSION, MSG, ...)           \
-  do {                                                                   \
-    auto _logger_sp = ::arrow::util::LoggerRegistry::GetDefaultLogger(); \
-    auto* _logger = _logger_sp.get();                                    \
-    if (_logger && (SEV >= _logger->severity_threshold())) {             \
-      ::gizmosql::LogWithFields(SEV, __FILE__, __LINE__, MSG,            \
-          ::gizmosql::FieldList{SESSION_KV_FIELDS(SESSION), __VA_ARGS__}); \
-    }                                                                    \
+// Session-aware dynamic-level logging with separate threshold and display severity.
+// THRESHOLD is the component's minimum level (e.g., query_log_level).
+// DISPLAY_SEV is the message's natural severity (e.g., INFO for routine logs).
+// See GIZMOSQL_LOGKV_DYNAMIC_AT for full semantics.
+#define GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT(THRESHOLD, DISPLAY_SEV, SESSION, MSG, ...) \
+  do {                                                                               \
+    auto _logger_sp = ::arrow::util::LoggerRegistry::GetDefaultLogger();             \
+    auto* _logger = _logger_sp.get();                                                \
+    if (_logger && (DISPLAY_SEV >= THRESHOLD) &&                                     \
+        (DISPLAY_SEV >= _logger->severity_threshold())) {                            \
+      ::gizmosql::LogWithFields(DISPLAY_SEV, __FILE__, __LINE__, MSG,                \
+          ::gizmosql::FieldList{SESSION_KV_FIELDS(SESSION), __VA_ARGS__});           \
+    }                                                                                \
   } while (0)
+
+// Convenience: session-aware dynamic-level logging where the threshold IS the display level
+#define GIZMOSQL_LOGKV_SESSION_DYNAMIC(SEV, SESSION, MSG, ...) \
+    GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT(SEV, SEV, SESSION, MSG, __VA_ARGS__)
 
 }  // namespace gizmosql

--- a/src/duckdb/duckdb_statement.cpp
+++ b/src/duckdb/duckdb_statement.cpp
@@ -657,8 +657,9 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
       instrumentation_catalog, instrumentation_schema);
 
   if (log_queries) {
-    GIZMOSQL_LOGKV_SESSION_DYNAMIC(
-        effective_log_level, client_session, "Client is attempting to run a SQL command",
+    GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT(
+        effective_log_level, arrow::util::ArrowLogLevel::ARROW_INFO,
+        client_session, "Client is attempting to run a SQL command",
         {"kind", "sql"}, {"status", "attempt"}, {"statement_id", handle},
         {"sql", logged_sql});
   }
@@ -759,8 +760,9 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
 #endif
 
     if (log_queries) {
-      GIZMOSQL_LOGKV_SESSION_DYNAMIC(
-          effective_log_level, client_session, "Detected GizmoSQL admin SET command",
+      GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT(
+          effective_log_level, arrow::util::ArrowLogLevel::ARROW_INFO,
+          client_session, "Detected GizmoSQL admin SET command",
           {"kind", "sql"}, {"status", "admin"}, {"statement_id", handle},
           {"sql", logged_sql});
     }
@@ -822,8 +824,9 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
         std::string::npos) {
       // Fallback to direct query execution for statements like PIVOT that get rewritten to multiple statements
       if (log_queries) {
-        GIZMOSQL_LOGKV_SESSION_DYNAMIC(
-            effective_log_level, client_session,
+        GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT(
+            effective_log_level, arrow::util::ArrowLogLevel::ARROW_INFO,
+            client_session,
             "SQL command cannot run as a prepared statement, falling back to direct "
             "query execution",
             {"kind", "sql"}, {"status", "fallback"},
@@ -1148,8 +1151,9 @@ arrow::Result<int> DuckDBStatement::Execute() {
           // The statement may have already been executed from the ComputeSchema() method - if so, just skip execution
           if (query_result_ != nullptr) {
             if (log_queries_) {
-              GIZMOSQL_LOGKV_SESSION_DYNAMIC(
-                  log_level, client_session_,
+              GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT(
+                  log_level, arrow::util::ArrowLogLevel::ARROW_INFO,
+                  client_session_,
                   "Direct execution of the SQL command has already occurred, skipping "
                   "re-execution",
                   {"kind", "sql"}, {"status", "already-executed"},
@@ -1190,8 +1194,9 @@ arrow::Result<int> DuckDBStatement::Execute() {
             }
             params_str << "]";
 
-            GIZMOSQL_LOGKV_SESSION_DYNAMIC(
-                log_level, client_session_, "Executing prepared statement with bind parameters",
+            GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT(
+                log_level, arrow::util::ArrowLogLevel::ARROW_INFO,
+                client_session_, "Executing prepared statement with bind parameters",
                 {"kind", "sql"}, {"status", "executing"},
                 {"statement_id", statement_id_}, {"bind_parameters", params_str.str()},
                 {"param_count", std::to_string(bind_parameters.size())},
@@ -1289,8 +1294,9 @@ arrow::Result<int> DuckDBStatement::Execute() {
 #endif
 
   if (log_queries_ && result.ok()) {
-    GIZMOSQL_LOGKV_SESSION_DYNAMIC(
-        log_level, client_session_, "Client SQL command execution succeeded",
+    GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT(
+        log_level, arrow::util::ArrowLogLevel::ARROW_INFO,
+        client_session_, "Client SQL command execution succeeded",
         {"kind", "sql"}, {"status", "success"}, {"statement_id", statement_id_},
         {"direct_execution", use_direct_execution_ ? "true" : "false"},
         {"duration_ms", GetLastExecutionDurationMs()}, {"sql", logged_sql_});

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(GIZMOSQL_CORE_TEST_SRCS
         integration/test_cross_instance_tokens.cpp
         integration/test_health_check.cpp
         integration/test_interactive_client.cpp
+        integration/test_log_level_filtering.cpp
         integration/test_sqlite_backend.cpp
         integration/test_token_authorized_emails.cpp
         integration/test_tpch_benchmark.cpp

--- a/tests/integration/test_log_level_filtering.cpp
+++ b/tests/integration/test_log_level_filtering.cpp
@@ -1,0 +1,308 @@
+// =============================================================================
+// Test: Log level filtering for query_log_level and auth_log_level
+// Verifies that GIZMOSQL_LOGKV_DYNAMIC_AT and GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT
+// correctly suppress messages whose natural severity is below the component
+// threshold, rather than promoting them to the threshold severity.
+// Regression test for https://github.com/gizmodata/gizmosql/issues/136
+// =============================================================================
+
+#include <gtest/gtest.h>
+
+#include <arrow/util/logger.h>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "detail/gizmosql_logging.h"
+
+using arrow::util::ArrowLogLevel;
+using arrow::util::LogDetails;
+using arrow::util::Logger;
+using arrow::util::LoggerRegistry;
+
+namespace {
+
+// A logger that captures every message for later assertion.
+class CapturingLogger final : public Logger {
+ public:
+  struct Entry {
+    ArrowLogLevel severity;
+    std::string message;
+  };
+
+  explicit CapturingLogger(ArrowLogLevel threshold) : threshold_(threshold) {}
+
+  bool is_enabled() const override { return true; }
+  ArrowLogLevel severity_threshold() const override { return threshold_; }
+
+  void Log(const LogDetails& d) override {
+    std::lock_guard<std::mutex> lk(mu_);
+    entries_.push_back({d.severity, std::string(d.message)});
+  }
+
+  std::vector<Entry> TakeEntries() {
+    std::lock_guard<std::mutex> lk(mu_);
+    auto result = std::move(entries_);
+    entries_.clear();
+    return result;
+  }
+
+ private:
+  ArrowLogLevel threshold_;
+  mutable std::mutex mu_;
+  std::vector<Entry> entries_;
+};
+
+// Minimal session-like struct that satisfies SESSION_KV_FIELDS(s) macro.
+// The macro reads: s->session_id, s->username, s->role, s->peer
+struct MockSession {
+  std::string session_id;
+  std::string username;
+  std::string role;
+  std::string peer;
+};
+
+}  // namespace
+
+class LogLevelFilteringTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    original_logger_ = LoggerRegistry::GetDefaultLogger();
+  }
+
+  void TearDown() override {
+    if (original_logger_) {
+      LoggerRegistry::SetDefaultLogger(original_logger_);
+    }
+  }
+
+  std::shared_ptr<CapturingLogger> InstallCapturingLogger(
+      ArrowLogLevel overall_threshold = ArrowLogLevel::ARROW_DEBUG) {
+    auto logger = std::make_shared<CapturingLogger>(overall_threshold);
+    LoggerRegistry::SetDefaultLogger(logger);
+    return logger;
+  }
+
+  std::shared_ptr<Logger> original_logger_;
+};
+
+// =============================================================================
+// GIZMOSQL_LOGKV_DYNAMIC_AT tests (used by auth logging)
+// =============================================================================
+
+TEST_F(LogLevelFilteringTest, DynamicAt_InfoMessageSuppressedWhenThresholdIsError) {
+  auto logger = InstallCapturingLogger(ArrowLogLevel::ARROW_DEBUG);
+
+  // Simulate: auth_log_level=ERROR, message natural level=INFO
+  GIZMOSQL_LOGKV_DYNAMIC_AT(
+      ArrowLogLevel::ARROW_ERROR, ArrowLogLevel::ARROW_INFO,
+      "Successful authentication", {"kind", "authentication"});
+
+  auto entries = logger->TakeEntries();
+  EXPECT_TRUE(entries.empty())
+      << "INFO message should be suppressed when component threshold is ERROR";
+}
+
+TEST_F(LogLevelFilteringTest, DynamicAt_InfoMessageShownWhenThresholdIsInfo) {
+  auto logger = InstallCapturingLogger(ArrowLogLevel::ARROW_DEBUG);
+
+  GIZMOSQL_LOGKV_DYNAMIC_AT(
+      ArrowLogLevel::ARROW_INFO, ArrowLogLevel::ARROW_INFO,
+      "Successful authentication", {"kind", "authentication"});
+
+  auto entries = logger->TakeEntries();
+  ASSERT_EQ(entries.size(), 1u);
+  EXPECT_EQ(entries[0].severity, ArrowLogLevel::ARROW_INFO);
+}
+
+TEST_F(LogLevelFilteringTest, DynamicAt_InfoMessageShownWhenThresholdIsDebug) {
+  auto logger = InstallCapturingLogger(ArrowLogLevel::ARROW_DEBUG);
+
+  GIZMOSQL_LOGKV_DYNAMIC_AT(
+      ArrowLogLevel::ARROW_DEBUG, ArrowLogLevel::ARROW_INFO,
+      "Successful authentication", {"kind", "authentication"});
+
+  auto entries = logger->TakeEntries();
+  ASSERT_EQ(entries.size(), 1u);
+  EXPECT_EQ(entries[0].severity, ArrowLogLevel::ARROW_INFO)
+      << "Display severity should be INFO regardless of threshold";
+}
+
+TEST_F(LogLevelFilteringTest, DynamicAt_ErrorMessageShownWhenThresholdIsError) {
+  auto logger = InstallCapturingLogger(ArrowLogLevel::ARROW_DEBUG);
+
+  GIZMOSQL_LOGKV_DYNAMIC_AT(
+      ArrowLogLevel::ARROW_ERROR, ArrowLogLevel::ARROW_ERROR,
+      "Authentication failed", {"kind", "authentication"});
+
+  auto entries = logger->TakeEntries();
+  ASSERT_EQ(entries.size(), 1u);
+  EXPECT_EQ(entries[0].severity, ArrowLogLevel::ARROW_ERROR);
+}
+
+TEST_F(LogLevelFilteringTest, DynamicAt_InfoSuppressedByOverallLoggerThreshold) {
+  // Overall logger threshold is WARNING, component threshold is DEBUG
+  auto logger = InstallCapturingLogger(ArrowLogLevel::ARROW_WARNING);
+
+  GIZMOSQL_LOGKV_DYNAMIC_AT(
+      ArrowLogLevel::ARROW_DEBUG, ArrowLogLevel::ARROW_INFO,
+      "Should be suppressed by overall threshold", {"kind", "test"});
+
+  auto entries = logger->TakeEntries();
+  EXPECT_TRUE(entries.empty())
+      << "INFO message should be suppressed when overall logger threshold is WARNING";
+}
+
+// =============================================================================
+// GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT tests (used by query logging)
+// =============================================================================
+
+class SessionLogLevelFilteringTest : public LogLevelFilteringTest {
+ protected:
+  void SetUp() override {
+    LogLevelFilteringTest::SetUp();
+    session_ = std::make_shared<MockSession>();
+    session_->session_id = "test-session-id";
+    session_->username = "testuser";
+    session_->role = "admin";
+    session_->peer = "ipv4:127.0.0.1:12345";
+  }
+
+  std::shared_ptr<MockSession> session_;
+};
+
+TEST_F(SessionLogLevelFilteringTest,
+       SessionDynamicAt_InfoMessageSuppressedWhenQueryLogLevelIsError) {
+  auto logger = InstallCapturingLogger(ArrowLogLevel::ARROW_DEBUG);
+
+  // Simulate: query_log_level=ERROR, message natural level=INFO
+  GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT(
+      ArrowLogLevel::ARROW_ERROR, ArrowLogLevel::ARROW_INFO,
+      session_, "Client SQL command execution succeeded",
+      {"kind", "sql"}, {"status", "success"});
+
+  auto entries = logger->TakeEntries();
+  EXPECT_TRUE(entries.empty())
+      << "INFO SQL log should be suppressed when query_log_level is ERROR";
+}
+
+TEST_F(SessionLogLevelFilteringTest,
+       SessionDynamicAt_InfoMessageShownWhenQueryLogLevelIsInfo) {
+  auto logger = InstallCapturingLogger(ArrowLogLevel::ARROW_DEBUG);
+
+  GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT(
+      ArrowLogLevel::ARROW_INFO, ArrowLogLevel::ARROW_INFO,
+      session_, "Client SQL command execution succeeded",
+      {"kind", "sql"}, {"status", "success"});
+
+  auto entries = logger->TakeEntries();
+  ASSERT_EQ(entries.size(), 1u);
+  EXPECT_EQ(entries[0].severity, ArrowLogLevel::ARROW_INFO);
+}
+
+TEST_F(SessionLogLevelFilteringTest,
+       SessionDynamicAt_DisplaySeverityIsAlwaysNaturalLevel) {
+  auto logger = InstallCapturingLogger(ArrowLogLevel::ARROW_DEBUG);
+
+  // Even with threshold=DEBUG, display should be INFO (the natural level)
+  GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT(
+      ArrowLogLevel::ARROW_DEBUG, ArrowLogLevel::ARROW_INFO,
+      session_, "Client is attempting to run a SQL command",
+      {"kind", "sql"}, {"status", "attempt"});
+
+  auto entries = logger->TakeEntries();
+  ASSERT_EQ(entries.size(), 1u);
+  EXPECT_EQ(entries[0].severity, ArrowLogLevel::ARROW_INFO)
+      << "Display severity must be INFO, not the component threshold";
+}
+
+TEST_F(SessionLogLevelFilteringTest,
+       SessionDynamicAt_WarningSuppressedWhenThresholdIsError) {
+  auto logger = InstallCapturingLogger(ArrowLogLevel::ARROW_DEBUG);
+
+  GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT(
+      ArrowLogLevel::ARROW_ERROR, ArrowLogLevel::ARROW_WARNING,
+      session_, "Query took a long time",
+      {"kind", "sql"}, {"status", "slow"});
+
+  auto entries = logger->TakeEntries();
+  EXPECT_TRUE(entries.empty())
+      << "WARNING message should be suppressed when threshold is ERROR";
+}
+
+TEST_F(SessionLogLevelFilteringTest,
+       SessionDynamicAt_ErrorShownWhenThresholdIsError) {
+  auto logger = InstallCapturingLogger(ArrowLogLevel::ARROW_DEBUG);
+
+  GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT(
+      ArrowLogLevel::ARROW_ERROR, ArrowLogLevel::ARROW_ERROR,
+      session_, "SQL execution failed",
+      {"kind", "sql"}, {"status", "failure"});
+
+  auto entries = logger->TakeEntries();
+  ASSERT_EQ(entries.size(), 1u);
+  EXPECT_EQ(entries[0].severity, ArrowLogLevel::ARROW_ERROR);
+}
+
+// =============================================================================
+// GIZMOSQL_LOGKV_SESSION_DYNAMIC convenience wrapper tests
+// =============================================================================
+
+TEST_F(SessionLogLevelFilteringTest,
+       SessionDynamic_ConvenienceWrapperUsesThresholdAsDisplayLevel) {
+  auto logger = InstallCapturingLogger(ArrowLogLevel::ARROW_DEBUG);
+
+  GIZMOSQL_LOGKV_SESSION_DYNAMIC(
+      ArrowLogLevel::ARROW_INFO, session_, "Test message",
+      {"kind", "test"}, {"status", "ok"});
+
+  auto entries = logger->TakeEntries();
+  ASSERT_EQ(entries.size(), 1u);
+  EXPECT_EQ(entries[0].severity, ArrowLogLevel::ARROW_INFO);
+}
+
+TEST_F(SessionLogLevelFilteringTest,
+       SessionDynamic_ConvenienceWrapperSuppressesWhenOverallThresholdHigher) {
+  // Overall logger threshold is ERROR
+  auto logger = InstallCapturingLogger(ArrowLogLevel::ARROW_ERROR);
+
+  GIZMOSQL_LOGKV_SESSION_DYNAMIC(
+      ArrowLogLevel::ARROW_INFO, session_, "Should be suppressed",
+      {"kind", "test"}, {"status", "ok"});
+
+  auto entries = logger->TakeEntries();
+  EXPECT_TRUE(entries.empty())
+      << "INFO message should be suppressed when overall threshold is ERROR";
+}
+
+// =============================================================================
+// Interaction between component threshold and overall logger threshold
+// =============================================================================
+
+TEST_F(LogLevelFilteringTest, BothThresholdsMustBeSatisfied) {
+  // Overall=WARNING, component=DEBUG → INFO should be suppressed by overall
+  auto logger = InstallCapturingLogger(ArrowLogLevel::ARROW_WARNING);
+
+  GIZMOSQL_LOGKV_DYNAMIC_AT(
+      ArrowLogLevel::ARROW_DEBUG, ArrowLogLevel::ARROW_INFO,
+      "Should not appear", {"kind", "test"});
+
+  auto entries = logger->TakeEntries();
+  EXPECT_TRUE(entries.empty())
+      << "INFO must be suppressed when overall threshold is WARNING, "
+         "even if component threshold is DEBUG";
+}
+
+TEST_F(LogLevelFilteringTest, WarningShownWhenBothThresholdsMet) {
+  // Overall=WARNING, component=INFO → WARNING should pass both
+  auto logger = InstallCapturingLogger(ArrowLogLevel::ARROW_WARNING);
+
+  GIZMOSQL_LOGKV_DYNAMIC_AT(
+      ArrowLogLevel::ARROW_INFO, ArrowLogLevel::ARROW_WARNING,
+      "Should appear at WARNING", {"kind", "test"});
+
+  auto entries = logger->TakeEntries();
+  ASSERT_EQ(entries.size(), 1u);
+  EXPECT_EQ(entries[0].severity, ArrowLogLevel::ARROW_WARNING);
+}


### PR DESCRIPTION
## Summary

- **Fix `GIZMOSQL_LOGKV_DYNAMIC_AT` macro**: The visibility check was `THRESHOLD >= logger_threshold` instead of `DISPLAY_SEV >= THRESHOLD && DISPLAY_SEV >= logger_threshold`. This caused INFO messages to be promoted to ERROR severity when `--query-log-level=error` instead of being suppressed.
- **Add `GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT` macro**: New session-aware variant with separate threshold and display severity parameters. The old `GIZMOSQL_LOGKV_SESSION_DYNAMIC` is now a convenience wrapper.
- **Update all 6 call sites** in `duckdb_statement.cpp` to use `_DYNAMIC_AT` with explicit `ARROW_INFO` display severity.
- **Add 14 unit tests** covering suppression, display severity correctness, and interaction between component and overall logger thresholds.

Fixes #136

## Test plan

- [ ] 14 new unit tests in `test_log_level_filtering.cpp` pass (tested locally)
- [ ] CI build and test pass
- [ ] Manual verification: set `--query-log-level=error` and confirm INFO SQL logs are suppressed, not promoted

🤖 Generated with [Claude Code](https://claude.com/claude-code)