### PR TITLE
Fix internal query log level filtering and add is_internal to logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Internal query log level filtering**: Internal queries (e.g., `DoGetTables`, `GetFlightInfoStatement`) now correctly use the session/server `query_log_level` as the threshold and the statement's own log level as the display severity. Previously the arguments were effectively swapped, causing internal queries marked as `ARROW_DEBUG` to leak into `INFO`-level logs. With this fix, internal queries are properly suppressed at the default `INFO` threshold and only appear when `query_log_level` is set to `DEBUG`.
+
+### Added
+
+- **`is_internal` attribute in query logs**: Query log entries now include an `is_internal` field (`true`/`false`) indicating whether the SQL statement originated from an internal Flight SQL endpoint (e.g., `DoGetTables`, `GetDbSchemas`) or from a user query. This aids in log filtering and debugging.
+
 ## [1.19.5] - 2026-03-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`is_internal` attribute in query logs**: Query log entries now include an `is_internal` field (`true`/`false`) indicating whether the SQL statement originated from an internal Flight SQL endpoint (e.g., `DoGetTables`, `GetDbSchemas`) or from a user query. This aids in log filtering and debugging.
+- **`is_internal` and `flight_method` attributes in query logs**: Query log entries now include `is_internal` (`true`/`false`) indicating whether the SQL statement originated from an internal Flight SQL endpoint, and `flight_method` (e.g., `DoGetTables`, `GetFlightInfoStatement`) identifying the originating RPC. These aid in log filtering and debugging.
 
 ## [1.19.5] - 2026-03-23
 

--- a/src/duckdb/duckdb_statement.cpp
+++ b/src/duckdb/duckdb_statement.cpp
@@ -752,7 +752,8 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
         log_threshold, display_severity,
         client_session, "Client is attempting to run a SQL command",
         {"kind", "sql"}, {"status", "attempt"}, {"statement_id", handle},
-        {"sql", logged_sql}, {"is_internal", is_internal ? "true" : "false"});
+        {"sql", logged_sql}, {"is_internal", is_internal ? "true" : "false"},
+        {"flight_method", flight_method});
   }
 
   // Prevent DETACH of instrumentation database (only relevant when enterprise is enabled)
@@ -803,7 +804,7 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
     // Return a synthetic result for the successful KILL SESSION command
     std::shared_ptr<DuckDBStatement> result(new DuckDBStatement(
         client_session, handle, sql, display_severity, log_queries, override_schema,
-        is_internal));
+        is_internal, flight_method));
     result->is_gizmosql_admin_ = true;
 
     // Create statement instrumentation for successful KILL SESSION
@@ -839,7 +840,7 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
   if (IsLikelyGizmoSQLSet(sql)) {
     std::shared_ptr<DuckDBStatement> result(new DuckDBStatement(
         client_session, handle, sql, display_severity, log_queries, override_schema,
-        is_internal));
+        is_internal, flight_method));
     result->is_gizmosql_admin_ = true;
 
 #ifdef GIZMOSQL_ENTERPRISE
@@ -857,7 +858,8 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
           log_threshold, display_severity,
           client_session, "Detected GizmoSQL admin SET command",
           {"kind", "sql"}, {"status", "admin"}, {"statement_id", handle},
-          {"sql", logged_sql}, {"is_internal", is_internal ? "true" : "false"});
+          {"sql", logged_sql}, {"is_internal", is_internal ? "true" : "false"},
+          {"flight_method", flight_method});
     }
     return result;
   }
@@ -924,12 +926,13 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
             "query execution",
             {"kind", "sql"}, {"status", "fallback"},
             {"statement_id", handle}, {"sql", logged_sql},
-            {"is_internal", is_internal ? "true" : "false"});
+            {"is_internal", is_internal ? "true" : "false"},
+            {"flight_method", flight_method});
       }
 
       std::shared_ptr<DuckDBStatement> result(new DuckDBStatement(
           client_session, handle, effective_sql, log_level, log_queries, override_schema,
-          is_internal));
+          is_internal, flight_method));
 
 #ifdef GIZMOSQL_ENTERPRISE
       // Create statement instrumentation for direct execution
@@ -971,7 +974,8 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
   }
 
   std::shared_ptr<DuckDBStatement> result(new DuckDBStatement(
-      client_session, handle, stmt, log_level, log_queries, override_schema, is_internal));
+      client_session, handle, stmt, log_level, log_queries, override_schema, is_internal,
+      flight_method));
 
 #ifdef GIZMOSQL_ENTERPRISE
   // Create statement instrumentation for prepared statement
@@ -1084,7 +1088,8 @@ DuckDBStatement::DuckDBStatement(const std::shared_ptr<ClientSession>& client_se
                                  const std::optional<arrow::util::ArrowLogLevel>& log_level,
                                  const bool& log_queries,
                                  const std::shared_ptr<arrow::Schema>& override_schema,
-                                 bool is_internal) {
+                                 bool is_internal,
+                                 std::string flight_method) {
   client_session_ = client_session;
   session_id_ = client_session->session_id;
   statement_id_ = handle;
@@ -1094,6 +1099,7 @@ DuckDBStatement::DuckDBStatement(const std::shared_ptr<ClientSession>& client_se
   use_direct_execution_ = false;
   log_level_ = log_level;
   is_internal_ = is_internal;
+  flight_method_ = std::move(flight_method);
   start_time_ = std::chrono::steady_clock::now();
   override_schema_ = override_schema;
   query_result_ = nullptr;
@@ -1111,7 +1117,8 @@ DuckDBStatement::DuckDBStatement(const std::shared_ptr<ClientSession>& client_se
                                  const std::optional<arrow::util::ArrowLogLevel>& log_level,
                                  const bool& log_queries,
                                  const std::shared_ptr<arrow::Schema>& override_schema,
-                                 bool is_internal) {
+                                 bool is_internal,
+                                 std::string flight_method) {
   client_session_ = client_session;
   session_id_ = client_session->session_id;
   statement_id_ = handle;
@@ -1122,6 +1129,7 @@ DuckDBStatement::DuckDBStatement(const std::shared_ptr<ClientSession>& client_se
   stmt_ = nullptr;
   log_level_ = log_level;
   is_internal_ = is_internal;
+  flight_method_ = std::move(flight_method);
   start_time_ = std::chrono::steady_clock::now();
   override_schema_ = override_schema;
   query_result_ = nullptr;
@@ -1267,7 +1275,8 @@ arrow::Result<int> DuckDBStatement::Execute() {
                   "re-execution",
                   {"kind", "sql"}, {"status", "already-executed"},
                   {"statement_id", statement_id_}, {"query_timeout", query_timeout},
-                  {"is_internal", is_internal_ ? "true" : "false"});
+                  {"is_internal", is_internal_ ? "true" : "false"},
+                  {"flight_method", flight_method_});
             }
             return 0;  // Success
           }
@@ -1311,7 +1320,8 @@ arrow::Result<int> DuckDBStatement::Execute() {
                 {"statement_id", statement_id_}, {"bind_parameters", params_str.str()},
                 {"param_count", std::to_string(bind_parameters.size())},
                 {"query_timeout", std::to_string(query_timeout)},
-                {"is_internal", is_internal_ ? "true" : "false"});
+                {"is_internal", is_internal_ ? "true" : "false"},
+                {"flight_method", flight_method_});
           }
 
           query_result_ = stmt_->Execute(bind_parameters);
@@ -1411,7 +1421,8 @@ arrow::Result<int> DuckDBStatement::Execute() {
         {"kind", "sql"}, {"status", "success"}, {"statement_id", statement_id_},
         {"direct_execution", use_direct_execution_ ? "true" : "false"},
         {"duration_ms", GetLastExecutionDurationMs()}, {"sql", logged_sql_},
-        {"is_internal", is_internal_ ? "true" : "false"});
+        {"is_internal", is_internal_ ? "true" : "false"},
+        {"flight_method", flight_method_});
   }
 
   record_query_metric(result.ok() ? "OK" : result.status().CodeAsString());

--- a/src/duckdb/duckdb_statement.cpp
+++ b/src/duckdb/duckdb_statement.cpp
@@ -656,13 +656,12 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
     const std::string& flight_method, bool is_internal) {
   std::string status;
   auto logged_sql = redact_sql_for_logs(sql);
-  arrow::util::ArrowLogLevel effective_log_level;
-  if (!log_level.has_value()) {
-    ARROW_ASSIGN_OR_RAISE(effective_log_level,
-                          GetSessionOrServerLogLevel(client_session));
-  } else {
-    effective_log_level = log_level.value();
-  }
+  // Threshold: session/server log level gates whether messages are emitted
+  ARROW_ASSIGN_OR_RAISE(auto log_threshold,
+                        GetSessionOrServerLogLevel(client_session));
+  // Display severity: statement's own level, defaulting to INFO for user queries
+  auto display_severity =
+      log_level.value_or(arrow::util::ArrowLogLevel::ARROW_INFO);
 
   GIZMOSQL_LOG_SCOPE_STATUS(
       DEBUG, "DuckDBStatement::Create", status, {"peer", client_session->peer},
@@ -750,10 +749,10 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
 
   if (log_queries) {
     GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT(
-        effective_log_level, arrow::util::ArrowLogLevel::ARROW_INFO,
+        log_threshold, display_severity,
         client_session, "Client is attempting to run a SQL command",
         {"kind", "sql"}, {"status", "attempt"}, {"statement_id", handle},
-        {"sql", logged_sql});
+        {"sql", logged_sql}, {"is_internal", is_internal ? "true" : "false"});
   }
 
   // Prevent DETACH of instrumentation database (only relevant when enterprise is enabled)
@@ -803,7 +802,8 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
 
     // Return a synthetic result for the successful KILL SESSION command
     std::shared_ptr<DuckDBStatement> result(new DuckDBStatement(
-        client_session, handle, sql, effective_log_level, log_queries, override_schema));
+        client_session, handle, sql, display_severity, log_queries, override_schema,
+        is_internal));
     result->is_gizmosql_admin_ = true;
 
     // Create statement instrumentation for successful KILL SESSION
@@ -838,7 +838,8 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
 
   if (IsLikelyGizmoSQLSet(sql)) {
     std::shared_ptr<DuckDBStatement> result(new DuckDBStatement(
-        client_session, handle, sql, effective_log_level, log_queries, override_schema));
+        client_session, handle, sql, display_severity, log_queries, override_schema,
+        is_internal));
     result->is_gizmosql_admin_ = true;
 
 #ifdef GIZMOSQL_ENTERPRISE
@@ -853,10 +854,10 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
 
     if (log_queries) {
       GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT(
-          effective_log_level, arrow::util::ArrowLogLevel::ARROW_INFO,
+          log_threshold, display_severity,
           client_session, "Detected GizmoSQL admin SET command",
           {"kind", "sql"}, {"status", "admin"}, {"statement_id", handle},
-          {"sql", logged_sql});
+          {"sql", logged_sql}, {"is_internal", is_internal ? "true" : "false"});
     }
     return result;
   }
@@ -917,16 +918,18 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
       // Fallback to direct query execution for statements like PIVOT that get rewritten to multiple statements
       if (log_queries) {
         GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT(
-            effective_log_level, arrow::util::ArrowLogLevel::ARROW_INFO,
+            log_threshold, display_severity,
             client_session,
             "SQL command cannot run as a prepared statement, falling back to direct "
             "query execution",
             {"kind", "sql"}, {"status", "fallback"},
-            {"statement_id", handle}, {"sql", logged_sql});
+            {"statement_id", handle}, {"sql", logged_sql},
+            {"is_internal", is_internal ? "true" : "false"});
       }
 
       std::shared_ptr<DuckDBStatement> result(new DuckDBStatement(
-          client_session, handle, effective_sql, log_level, log_queries, override_schema));
+          client_session, handle, effective_sql, log_level, log_queries, override_schema,
+          is_internal));
 
 #ifdef GIZMOSQL_ENTERPRISE
       // Create statement instrumentation for direct execution
@@ -968,7 +971,7 @@ arrow::Result<std::shared_ptr<DuckDBStatement>> DuckDBStatement::Create(
   }
 
   std::shared_ptr<DuckDBStatement> result(new DuckDBStatement(
-      client_session, handle, stmt, log_level, log_queries, override_schema));
+      client_session, handle, stmt, log_level, log_queries, override_schema, is_internal));
 
 #ifdef GIZMOSQL_ENTERPRISE
   // Create statement instrumentation for prepared statement
@@ -1080,7 +1083,8 @@ DuckDBStatement::DuckDBStatement(const std::shared_ptr<ClientSession>& client_se
                                  const std::shared_ptr<duckdb::PreparedStatement>& stmt,
                                  const std::optional<arrow::util::ArrowLogLevel>& log_level,
                                  const bool& log_queries,
-                                 const std::shared_ptr<arrow::Schema>& override_schema) {
+                                 const std::shared_ptr<arrow::Schema>& override_schema,
+                                 bool is_internal) {
   client_session_ = client_session;
   session_id_ = client_session->session_id;
   statement_id_ = handle;
@@ -1089,6 +1093,7 @@ DuckDBStatement::DuckDBStatement(const std::shared_ptr<ClientSession>& client_se
   logged_sql_ = redact_sql_for_logs(stmt->query);
   use_direct_execution_ = false;
   log_level_ = log_level;
+  is_internal_ = is_internal;
   start_time_ = std::chrono::steady_clock::now();
   override_schema_ = override_schema;
   query_result_ = nullptr;
@@ -1105,7 +1110,8 @@ DuckDBStatement::DuckDBStatement(const std::shared_ptr<ClientSession>& client_se
                                  const std::string& handle, const std::string& sql,
                                  const std::optional<arrow::util::ArrowLogLevel>& log_level,
                                  const bool& log_queries,
-                                 const std::shared_ptr<arrow::Schema>& override_schema) {
+                                 const std::shared_ptr<arrow::Schema>& override_schema,
+                                 bool is_internal) {
   client_session_ = client_session;
   session_id_ = client_session->session_id;
   statement_id_ = handle;
@@ -1115,6 +1121,7 @@ DuckDBStatement::DuckDBStatement(const std::shared_ptr<ClientSession>& client_se
   use_direct_execution_ = true;
   stmt_ = nullptr;
   log_level_ = log_level;
+  is_internal_ = is_internal;
   start_time_ = std::chrono::steady_clock::now();
   override_schema_ = override_schema;
   query_result_ = nullptr;
@@ -1133,7 +1140,11 @@ arrow::Result<int> DuckDBStatement::Execute() {
   std::string execute_status;
 
   ARROW_ASSIGN_OR_RAISE(auto query_timeout, GetQueryTimeout());
-  ARROW_ASSIGN_OR_RAISE(auto log_level, GetLogLevel());
+  // Threshold: session/server log level gates whether messages are emitted
+  ARROW_ASSIGN_OR_RAISE(auto log_threshold, GetSessionOrServerLogLevel(session));
+  // Display severity: statement's own level, defaulting to INFO for user queries
+  auto log_level =
+      log_level_.value_or(arrow::util::ArrowLogLevel::ARROW_INFO);
   start_time_ = std::chrono::steady_clock::now();
 
   const std::string metric_operation =
@@ -1231,7 +1242,7 @@ arrow::Result<int> DuckDBStatement::Execute() {
 
   // Launch execution in a separate thread
   auto future = std::async(
-      std::launch::async, [this, session, query_timeout, log_level
+      std::launch::async, [this, session, query_timeout, log_threshold, log_level
 #ifdef GIZMOSQL_WITH_OPENTELEMETRY
                            ,
                            telemetry_context,
@@ -1250,12 +1261,13 @@ arrow::Result<int> DuckDBStatement::Execute() {
           if (query_result_ != nullptr) {
             if (log_queries_) {
               GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT(
-                  log_level, arrow::util::ArrowLogLevel::ARROW_INFO,
+                  log_threshold, log_level,
                   session,
                   "Direct execution of the SQL command has already occurred, skipping "
                   "re-execution",
                   {"kind", "sql"}, {"status", "already-executed"},
-                  {"statement_id", statement_id_}, {"query_timeout", query_timeout});
+                  {"statement_id", statement_id_}, {"query_timeout", query_timeout},
+                  {"is_internal", is_internal_ ? "true" : "false"});
             }
             return 0;  // Success
           }
@@ -1293,12 +1305,13 @@ arrow::Result<int> DuckDBStatement::Execute() {
             params_str << "]";
 
             GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT(
-                log_level, arrow::util::ArrowLogLevel::ARROW_INFO,
+                log_threshold, log_level,
                 session, "Executing prepared statement with bind parameters",
                 {"kind", "sql"}, {"status", "executing"},
                 {"statement_id", statement_id_}, {"bind_parameters", params_str.str()},
                 {"param_count", std::to_string(bind_parameters.size())},
-                {"query_timeout", std::to_string(query_timeout)});
+                {"query_timeout", std::to_string(query_timeout)},
+                {"is_internal", is_internal_ ? "true" : "false"});
           }
 
           query_result_ = stmt_->Execute(bind_parameters);
@@ -1393,11 +1406,12 @@ arrow::Result<int> DuckDBStatement::Execute() {
 
   if (log_queries_ && result.ok()) {
     GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT(
-        log_level, arrow::util::ArrowLogLevel::ARROW_INFO,
+        log_threshold, log_level,
         session, "Client SQL command execution succeeded",
         {"kind", "sql"}, {"status", "success"}, {"statement_id", statement_id_},
         {"direct_execution", use_direct_execution_ ? "true" : "false"},
-        {"duration_ms", GetLastExecutionDurationMs()}, {"sql", logged_sql_});
+        {"duration_ms", GetLastExecutionDurationMs()}, {"sql", logged_sql_},
+        {"is_internal", is_internal_ ? "true" : "false"});
   }
 
   record_query_metric(result.ok() ? "OK" : result.status().CodeAsString());

--- a/src/duckdb/duckdb_statement.h
+++ b/src/duckdb/duckdb_statement.h
@@ -121,6 +121,7 @@ class DuckDBStatement {
   bool is_gizmosql_admin_ =
       false;  // Flag to indicate whether the statement is a GizmoSQL administrative command
   bool is_internal_ = false;  // Flag to indicate whether the statement is an internal query
+  std::string flight_method_;  // The Flight RPC method that created this statement
   duckdb::shared_ptr<duckdb::ClientContext> client_context_;
 #ifdef GIZMOSQL_WITH_OPENTELEMETRY
   std::string creation_trace_id_;
@@ -137,7 +138,8 @@ class DuckDBStatement {
                   const std::optional<arrow::util::ArrowLogLevel>& log_level,
                   const bool& log_queries,
                   const std::shared_ptr<arrow::Schema>& override_schema,
-                  bool is_internal = false);
+                  bool is_internal = false,
+                  std::string flight_method = "");
 
   // Constructor for direct execution mode
   DuckDBStatement(const std::shared_ptr<ClientSession>& client_session,
@@ -145,7 +147,8 @@ class DuckDBStatement {
                   const std::optional<arrow::util::ArrowLogLevel>& log_level,
                   const bool& log_queries,
                   const std::shared_ptr<arrow::Schema>& override_schema,
-                  bool is_internal = false);
+                  bool is_internal = false,
+                  std::string flight_method = "");
 
   arrow::Status HandleGizmoSQLSet();
 

--- a/src/duckdb/duckdb_statement.h
+++ b/src/duckdb/duckdb_statement.h
@@ -120,6 +120,7 @@ class DuckDBStatement {
   bool use_direct_execution_;  // Flag to indicate whether to use direct query execution
   bool is_gizmosql_admin_ =
       false;  // Flag to indicate whether the statement is a GizmoSQL administrative command
+  bool is_internal_ = false;  // Flag to indicate whether the statement is an internal query
   duckdb::shared_ptr<duckdb::ClientContext> client_context_;
 #ifdef GIZMOSQL_WITH_OPENTELEMETRY
   std::string creation_trace_id_;
@@ -135,14 +136,16 @@ class DuckDBStatement {
                   const std::shared_ptr<duckdb::PreparedStatement>& stmt,
                   const std::optional<arrow::util::ArrowLogLevel>& log_level,
                   const bool& log_queries,
-                  const std::shared_ptr<arrow::Schema>& override_schema);
+                  const std::shared_ptr<arrow::Schema>& override_schema,
+                  bool is_internal = false);
 
   // Constructor for direct execution mode
   DuckDBStatement(const std::shared_ptr<ClientSession>& client_session,
                   const std::string& handle, const std::string& sql,
                   const std::optional<arrow::util::ArrowLogLevel>& log_level,
                   const bool& log_queries,
-                  const std::shared_ptr<arrow::Schema>& override_schema);
+                  const std::shared_ptr<arrow::Schema>& override_schema,
+                  bool is_internal = false);
 
   arrow::Status HandleGizmoSQLSet();
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(GIZMOSQL_CORE_TEST_SRCS
         integration/test_cross_instance_tokens.cpp
         integration/test_health_check.cpp
         integration/test_interactive_client.cpp
+        integration/test_internal_query_log_level.cpp
         integration/test_log_level_filtering.cpp
         integration/test_sqlite_backend.cpp
         integration/test_token_authorized_emails.cpp

--- a/tests/integration/test_internal_query_log_level.cpp
+++ b/tests/integration/test_internal_query_log_level.cpp
@@ -1,0 +1,268 @@
+// =============================================================================
+// Test: Internal query log level filtering
+// Verifies that internal queries (e.g., DoGetTables) are logged at DEBUG
+// severity and are correctly suppressed when the server's query_log_level
+// threshold is INFO (the default), and emitted when the threshold is DEBUG.
+// =============================================================================
+
+#include <gtest/gtest.h>
+
+#include <arrow/array.h>
+#include <arrow/flight/client.h>
+#include <arrow/flight/sql/client.h>
+#include <arrow/table.h>
+#include <arrow/util/logger.h>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "test_server_fixture.h"
+#include "test_util.h"
+
+using arrow::util::ArrowLogLevel;
+using arrow::util::LogDetails;
+using arrow::util::Logger;
+using arrow::util::LoggerRegistry;
+using arrow::flight::sql::FlightSqlClient;
+
+namespace {
+
+// A logger that captures every message for later assertion.
+class CapturingLogger final : public Logger {
+ public:
+  struct Entry {
+    ArrowLogLevel severity;
+    std::string message;
+  };
+
+  explicit CapturingLogger(ArrowLogLevel threshold) : threshold_(threshold) {}
+
+  bool is_enabled() const override { return true; }
+  ArrowLogLevel severity_threshold() const override { return threshold_; }
+
+  void Log(const LogDetails& d) override {
+    std::lock_guard<std::mutex> lk(mu_);
+    entries_.push_back({d.severity, std::string(d.message)});
+  }
+
+  std::vector<Entry> TakeEntries() {
+    std::lock_guard<std::mutex> lk(mu_);
+    auto result = std::move(entries_);
+    entries_.clear();
+    return result;
+  }
+
+ private:
+  ArrowLogLevel threshold_;
+  mutable std::mutex mu_;
+  std::vector<Entry> entries_;
+};
+
+}  // namespace
+
+// =============================================================================
+// Fixture: Server with query_log_level=INFO (default), print_queries=true
+// Internal queries (DoGetTables) should be suppressed at this threshold.
+// =============================================================================
+class InternalQueryLogInfoFixture
+    : public gizmosql::testing::ServerTestFixture<InternalQueryLogInfoFixture> {
+ public:
+  static gizmosql::testing::TestServerConfig GetConfig() {
+    return {
+        .database_filename = "internal_query_log_info_test.db",
+        .port = 31400,
+        .health_port = 31401,
+        .username = "testuser",
+        .password = "testpassword",
+        .enable_instrumentation = false,
+        .init_sql_commands = "CREATE TABLE log_test_table (id INTEGER, name VARCHAR);",
+        .print_queries = true,
+        .query_log_level = ArrowLogLevel::ARROW_INFO,
+    };
+  }
+};
+
+template <>
+std::shared_ptr<arrow::flight::sql::FlightSqlServerBase>
+    gizmosql::testing::ServerTestFixture<InternalQueryLogInfoFixture>::server_{};
+template <>
+std::thread
+    gizmosql::testing::ServerTestFixture<InternalQueryLogInfoFixture>::server_thread_{};
+template <>
+std::atomic<bool>
+    gizmosql::testing::ServerTestFixture<InternalQueryLogInfoFixture>::server_ready_{false};
+template <>
+gizmosql::testing::TestServerConfig
+    gizmosql::testing::ServerTestFixture<InternalQueryLogInfoFixture>::config_{};
+
+// =============================================================================
+// Fixture: Server with query_log_level=DEBUG, print_queries=true
+// Internal queries (DoGetTables) should be emitted at this threshold.
+// =============================================================================
+class InternalQueryLogDebugFixture
+    : public gizmosql::testing::ServerTestFixture<InternalQueryLogDebugFixture> {
+ public:
+  static gizmosql::testing::TestServerConfig GetConfig() {
+    return {
+        .database_filename = "internal_query_log_debug_test.db",
+        .port = 31402,
+        .health_port = 31403,
+        .username = "testuser",
+        .password = "testpassword",
+        .enable_instrumentation = false,
+        .init_sql_commands = "CREATE TABLE log_test_table (id INTEGER, name VARCHAR);",
+        .print_queries = true,
+        .query_log_level = ArrowLogLevel::ARROW_DEBUG,
+    };
+  }
+};
+
+template <>
+std::shared_ptr<arrow::flight::sql::FlightSqlServerBase>
+    gizmosql::testing::ServerTestFixture<InternalQueryLogDebugFixture>::server_{};
+template <>
+std::thread
+    gizmosql::testing::ServerTestFixture<InternalQueryLogDebugFixture>::server_thread_{};
+template <>
+std::atomic<bool>
+    gizmosql::testing::ServerTestFixture<InternalQueryLogDebugFixture>::server_ready_{
+        false};
+template <>
+gizmosql::testing::TestServerConfig
+    gizmosql::testing::ServerTestFixture<InternalQueryLogDebugFixture>::config_{};
+
+// =============================================================================
+// Helper: Connect, authenticate, and call GetTables
+// =============================================================================
+static arrow::Result<std::shared_ptr<arrow::Table>> CallGetTables(
+    int port, const std::string& username, const std::string& password) {
+  ARROW_ASSIGN_OR_RAISE(auto location,
+                         arrow::flight::Location::ForGrpcTcp("localhost", port));
+  arrow::flight::FlightClientOptions client_options;
+  ARROW_ASSIGN_OR_RAISE(auto client,
+                         arrow::flight::FlightClient::Connect(location, client_options));
+
+  arrow::flight::FlightCallOptions call_options;
+  ARROW_ASSIGN_OR_RAISE(auto bearer,
+                         client->AuthenticateBasicToken({}, username, password));
+  call_options.headers.push_back(bearer);
+
+  FlightSqlClient sql_client(std::move(client));
+
+  ARROW_ASSIGN_OR_RAISE(
+      auto info,
+      sql_client.GetTables(call_options,
+                           /*catalog=*/nullptr,
+                           /*db_schema_filter_pattern=*/nullptr,
+                           /*table_filter_pattern=*/nullptr,
+                           /*include_schema=*/false,
+                           /*table_types=*/nullptr));
+
+  // Read all results
+  std::shared_ptr<arrow::Table> combined;
+  for (const auto& endpoint : info->endpoints()) {
+    ARROW_ASSIGN_OR_RAISE(auto reader,
+                           sql_client.DoGet(call_options, endpoint.ticket));
+    ARROW_ASSIGN_OR_RAISE(combined, reader->ToTable());
+  }
+  return combined;
+}
+
+// =============================================================================
+// Test: INFO threshold suppresses internal DoGetTables query logs
+// =============================================================================
+TEST_F(InternalQueryLogInfoFixture, DoGetTablesNotLoggedAtInfoThreshold) {
+  ASSERT_TRUE(IsServerReady()) << "Server not ready";
+
+  // Save original logger and install capturing logger
+  auto original_logger = LoggerRegistry::GetDefaultLogger();
+  auto capturing_logger = std::make_shared<CapturingLogger>(ArrowLogLevel::ARROW_DEBUG);
+  LoggerRegistry::SetDefaultLogger(capturing_logger);
+
+  // Call DoGetTables — this triggers internal queries in the server
+  ASSERT_ARROW_OK_AND_ASSIGN(auto table,
+                              CallGetTables(GetPort(), GetUsername(), GetPassword()));
+
+  // Restore the original logger
+  LoggerRegistry::SetDefaultLogger(original_logger);
+
+  // Verify the endpoint actually worked — our init_sql created log_test_table
+  ASSERT_GT(table->num_rows(), 0) << "GetTables should return at least one table";
+
+  // Check that log_test_table is present in the results
+  auto table_name_col = table->GetColumnByName("table_name");
+  ASSERT_NE(table_name_col, nullptr) << "Expected 'table_name' column in GetTables result";
+  bool found_table = false;
+  for (int chunk = 0; chunk < table_name_col->num_chunks(); ++chunk) {
+    auto array = std::static_pointer_cast<arrow::StringArray>(table_name_col->chunk(chunk));
+    for (int64_t i = 0; i < array->length(); ++i) {
+      if (!array->IsNull(i) && array->GetString(i) == "log_test_table") {
+        found_table = true;
+      }
+    }
+  }
+  ASSERT_TRUE(found_table) << "GetTables should include 'log_test_table'";
+
+  // Verify that NO internal query logs were emitted (they have DEBUG severity,
+  // which should be suppressed by the INFO query_log_level threshold)
+  auto entries = capturing_logger->TakeEntries();
+  for (const auto& entry : entries) {
+    if (entry.message.find("\"is_internal\":\"true\"") != std::string::npos) {
+      FAIL() << "Internal query log should NOT be emitted at INFO threshold, but found: "
+             << entry.message;
+    }
+  }
+}
+
+// =============================================================================
+// Test: DEBUG threshold allows internal DoGetTables query logs through
+// =============================================================================
+TEST_F(InternalQueryLogDebugFixture, DoGetTablesLoggedAtDebugThreshold) {
+  ASSERT_TRUE(IsServerReady()) << "Server not ready";
+
+  // Save original logger and install capturing logger
+  auto original_logger = LoggerRegistry::GetDefaultLogger();
+  auto capturing_logger = std::make_shared<CapturingLogger>(ArrowLogLevel::ARROW_DEBUG);
+  LoggerRegistry::SetDefaultLogger(capturing_logger);
+
+  // Call DoGetTables — this triggers internal queries in the server
+  ASSERT_ARROW_OK_AND_ASSIGN(auto table,
+                              CallGetTables(GetPort(), GetUsername(), GetPassword()));
+
+  // Restore the original logger
+  LoggerRegistry::SetDefaultLogger(original_logger);
+
+  // Verify the endpoint actually worked — our init_sql created log_test_table
+  ASSERT_GT(table->num_rows(), 0) << "GetTables should return at least one table";
+
+  // Check that log_test_table is present in the results
+  auto table_name_col = table->GetColumnByName("table_name");
+  ASSERT_NE(table_name_col, nullptr) << "Expected 'table_name' column in GetTables result";
+  bool found_table = false;
+  for (int chunk = 0; chunk < table_name_col->num_chunks(); ++chunk) {
+    auto array = std::static_pointer_cast<arrow::StringArray>(table_name_col->chunk(chunk));
+    for (int64_t i = 0; i < array->length(); ++i) {
+      if (!array->IsNull(i) && array->GetString(i) == "log_test_table") {
+        found_table = true;
+      }
+    }
+  }
+  ASSERT_TRUE(found_table) << "GetTables should include 'log_test_table'";
+
+  // Verify that internal query logs WERE emitted (they have DEBUG severity,
+  // which should pass the DEBUG query_log_level threshold)
+  auto entries = capturing_logger->TakeEntries();
+  bool found_internal_log = false;
+  for (const auto& entry : entries) {
+    if (entry.message.find("\"is_internal\":\"true\"") != std::string::npos) {
+      found_internal_log = true;
+      EXPECT_EQ(entry.severity, ArrowLogLevel::ARROW_DEBUG)
+          << "Internal query logs should be emitted at DEBUG severity";
+      break;
+    }
+  }
+  ASSERT_TRUE(found_internal_log)
+      << "Expected at least one internal query log entry with is_internal=true "
+         "when query_log_level is DEBUG";
+}

--- a/tests/integration/test_server_fixture.h
+++ b/tests/integration/test_server_fixture.h
@@ -104,6 +104,9 @@ struct TestServerConfig {
   std::string oauth_redirect_uri = "";          // OAuth redirect URI override (takes precedence over derived)
   std::string oauth_instance_id = "";           // Instance ID for multi-instance OAuth proxy routing
   bool oauth_disable_tls = false;               // Disable TLS on OAuth callback server
+  bool print_queries = false;                    // Enable query logging
+  arrow::util::ArrowLogLevel query_log_level =
+      arrow::util::ArrowLogLevel::ARROW_INFO;    // Query log level threshold
 };
 
 /// CRTP-based test fixture template for integration tests.
@@ -174,7 +177,7 @@ class ServerTestFixture : public ::testing::Test {
         /*mtls_ca_cert_path=*/fs::path(),
         /*init_sql_commands=*/config_.init_sql_commands,
         /*init_sql_commands_file=*/fs::path(),
-        /*print_queries=*/false,
+        /*print_queries=*/config_.print_queries,
         /*read_only=*/false,
         /*token_allowed_issuer=*/config_.token_allowed_issuer,
         /*token_allowed_audience=*/config_.token_allowed_audience,
@@ -184,7 +187,7 @@ class ServerTestFixture : public ::testing::Test {
         /*token_authorized_emails=*/config_.token_authorized_emails,
         /*access_logging_enabled=*/false,
         /*query_timeout=*/0,
-        /*query_log_level=*/arrow::util::ArrowLogLevel::ARROW_INFO,
+        /*query_log_level=*/config_.query_log_level,
         /*auth_log_level=*/arrow::util::ArrowLogLevel::ARROW_INFO,
         /*health_port=*/config_.health_port,
         /*health_check_query=*/config_.health_check_query,


### PR DESCRIPTION
## Summary

- **Fix log level threshold/display swap**: Internal queries (e.g., `DoGetTables`, `GetDbSchemas`, `GetFlightInfoStatement`) pass `ARROW_DEBUG` as their statement log level. The `GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT` calls had the threshold and display severity arguments effectively reversed — the statement's log level was used as the threshold instead of the session/server `query_log_level`. This caused internal DEBUG queries to leak into INFO-level logs. Now `GetSessionOrServerLogLevel()` is always used as the threshold (arg 1) and the statement's own level as the display severity (arg 2, defaulting to INFO for user queries).
- **Add `is_internal` to DuckDBStatement and query logs**: Added `is_internal` as a constructor parameter (default `false`) and member on `DuckDBStatement`. All 6 `GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT` call sites now include `{"is_internal", "true"/"false"}` for easier log filtering.
- **Add `print_queries` and `query_log_level` to TestServerConfig**: Test fixtures can now configure these settings instead of using hardcoded defaults.
- **New integration tests**: Two tests validate the fix end-to-end by calling `DoGetTables`, verifying the table result includes a test table created via `init_sql_commands`, and asserting on log capture behavior at INFO vs DEBUG thresholds.

## Test plan

- [x] `InternalQueryLogInfoFixture.DoGetTablesNotLoggedAtInfoThreshold` — verifies internal query logs are suppressed at default INFO threshold
- [x] `InternalQueryLogDebugFixture.DoGetTablesLoggedAtDebugThreshold` — verifies internal query logs emit at DEBUG severity when threshold is DEBUG
- [x] Both tests also validate that `DoGetTables` returns `log_test_table` created via init SQL
- [x] Full build passes (`ninja` — no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)