### PR TITLE
Fix independent query/auth log level thresholds and SET GLOBAL propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`query_log_level` now independent of `--log-level`**: `SET gizmosql.query_log_level = DEBUG` (or `--query-log-level debug`) now correctly emits DEBUG query logs even when the global `--log-level` is `info`. Previously, the global logger threshold acted as an additional gate that suppressed query logs below its level.
+- **`SET GLOBAL` propagates immediately to existing sessions**: `SET GLOBAL gizmosql.query_log_level` and `SET GLOBAL gizmosql.query_timeout` now take effect immediately for all existing sessions that haven't set a session-level override. Previously, the server's default was baked into each session at creation time, requiring a reconnect to pick up global changes.
+- **Auth log level threshold for bearer token validation**: Bearer token validation logs now correctly use `auth_log_level` as the threshold. Previously, repeat token validations could bypass the threshold because `GetTokenLogLevel()` was used as both the threshold and display severity.
+
+### Added
+
+- **`docs/set_commands.md`**: New documentation for `SET gizmosql.*` commands covering `query_log_level` and `query_timeout` with session/global scope, valid values, and admin restrictions.
+
 ## [1.19.6] - 2026-03-24
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,46 @@ ninja gizmosql_integration_tests
 - Use `GIZMOSQL_LOGKV(level, message, ...)` for structured key-value logging
 - Levels: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `FATAL`
 
+### Component Log Level Architecture (CRITICAL — Do Not Regress)
+
+GizmoSQL has **three independent log level controls**. Each uses a **threshold** (minimum severity to emit) and a **display severity** (the level the message is logged at). These must remain independent:
+
+| Control | CLI flag | Env var | Scope | What it gates |
+|---------|----------|---------|-------|---------------|
+| **Global log level** | `--log-level` | `GIZMOSQL_LOG_LEVEL` | Process-wide | All non-component log messages |
+| **Query log level** | `--query-log-level` | `GIZMOSQL_QUERY_LOG_LEVEL` | Server default; overridable per-session via `SET gizmosql.query_log_level` | Query execution logs (attempt/success/failure) |
+| **Auth log level** | `--auth-log-level` | `GIZMOSQL_AUTH_LOG_LEVEL` | Server-wide | Authentication/token validation logs |
+
+#### Macro usage rules
+
+| Macro | Threshold check | Used by |
+|-------|----------------|---------|
+| `GIZMOSQL_LOGKV(SEV, ...)` | Global logger `severity_threshold()` | General logging |
+| `GIZMOSQL_LOGKV_SESSION(SEV, ...)` | Global logger `severity_threshold()` | Session-aware general logging |
+| `GIZMOSQL_LOGKV_DYNAMIC_AT(THRESHOLD, DISPLAY_SEV, ...)` | `DISPLAY_SEV >= THRESHOLD` **AND** `DISPLAY_SEV >= global severity_threshold()` | **Auth logging** (`gizmosql_security.cpp`) |
+| `GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT(THRESHOLD, DISPLAY_SEV, ...)` | `DISPLAY_SEV >= THRESHOLD` **only** (bypasses global logger via `LogWithFieldsUnchecked`) | **Query logging** (`duckdb_statement.cpp`) |
+
+**Why the asymmetry?** `query_log_level` is settable per-session at runtime via `SET gizmosql.query_log_level = DEBUG`, so it must be able to independently override the global log level. Auth log level is server-wide and set at startup, so it correctly defers to the global logger threshold as an additional gate.
+
+#### Key invariants (regression tests exist for all of these):
+
+1. **`query_log_level` is independent of `--log-level`**: Setting `query_log_level = DEBUG` (via SET or CLI) must emit DEBUG query logs even when `--log-level` is `info`. This is achieved by `GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT` calling `LogWithFieldsUnchecked()` which skips the global `severity_threshold()` check.
+
+2. **`auth_log_level` respects `--log-level`**: Auth logs use `GIZMOSQL_LOGKV_DYNAMIC_AT` which checks **both** the component threshold AND the global logger threshold. A DEBUG auth message is suppressed when `--log-level` is `info`.
+
+3. **Bearer token display severity**: `GetTokenLogLevel()` in `gizmosql_security.cpp` returns the **display severity** only — `ARROW_INFO` for first-seen tokens, `ARROW_DEBUG` for repeat tokens. It must **never** return `auth_log_level_`. The threshold argument to the macro must always be `auth_log_level_`.
+
+4. **Internal query display severity**: Internal queries (DoGetTables, GetDbSchemas, etc.) pass `ARROW_DEBUG` as their display severity in `DuckDBStatement::Create()`. At the default `query_log_level = INFO`, these are suppressed (`DEBUG < INFO`). At `query_log_level = DEBUG`, they appear.
+
+5. **Session vs server fallback for `query_log_level`**: `GetSessionOrServerLogLevel()` checks `session->query_log_level` first (set via session-level SET), then falls back to the server's global value (set via `--query-log-level`, env var, or `SET GLOBAL`).
+
+#### Test coverage
+
+- `test_log_level_filtering.cpp` — Unit tests for macro threshold behavior
+- `test_internal_query_log_level.cpp` — Internal query suppression at INFO / emission at DEBUG
+- `test_set_query_log_level.cpp` — Session-level SET dynamically changes threshold
+- `test_auth_log_level.cpp` — Repeat bearer tokens suppressed at INFO, first-seen logged at INFO
+
 ### Error Handling
 - Use Arrow's `Status` and `Result<T>` types
 - Use `ARROW_RETURN_NOT_OK()` and `ARROW_ASSIGN_OR_RAISE()` macros

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -13,6 +13,7 @@
   * [Geometry & Spatial](geometry.md)
 
 * Features
+  * [SET Commands](set_commands.md)
   * [Session Instrumentation](session_instrumentation.md) *(Enterprise)*
   * [OpenTelemetry Integration](opentelemetry.md)
 

--- a/docs/set_commands.md
+++ b/docs/set_commands.md
@@ -1,0 +1,86 @@
+# SET Commands
+
+GizmoSQL supports server-specific `SET` commands that configure session-level and server-level behavior at runtime. These commands use the `gizmosql.` prefix to distinguish them from DuckDB's built-in `SET` commands.
+
+## Syntax
+
+```sql
+-- Session scope (affects only the current connection)
+SET gizmosql.<parameter> = <value>;
+SET SESSION gizmosql.<parameter> = <value>;
+
+-- Global scope (affects all sessions; requires admin role)
+SET GLOBAL gizmosql.<parameter> = <value>;
+```
+
+When no scope is specified, the default is **session** scope.
+
+## Parameters
+
+### `gizmosql.query_log_level`
+
+Controls the minimum severity threshold for query log messages.
+
+| Property | Value |
+|----------|-------|
+| **Type** | String |
+| **Valid values** | `debug`, `info`, `warn` (or `warning`), `error`, `fatal` |
+| **Default** | `info` |
+| **CLI flag** | `--query-log-level` |
+| **Environment variable** | `GIZMOSQL_QUERY_LOG_LEVEL` |
+
+When set to `debug`, internal queries (e.g., `DoGetTables`, `GetDbSchemas`) will appear in the logs. At the default `info` level, these internal queries are suppressed.
+
+**Examples:**
+
+```sql
+-- Show all query logs including internal/debug queries (session only)
+SET gizmosql.query_log_level = debug;
+
+-- Suppress all query logs except errors and above (session only)
+SET gizmosql.query_log_level = error;
+
+-- Set the server-wide default to debug (requires admin role)
+SET GLOBAL gizmosql.query_log_level = debug;
+```
+
+### `gizmosql.query_timeout`
+
+Controls the maximum execution time for queries, in seconds.
+
+| Property | Value |
+|----------|-------|
+| **Type** | Integer (seconds) |
+| **Default** | `0` (unlimited) |
+| **CLI flag** | `--query-timeout` |
+| **Environment variable** | `GIZMOSQL_QUERY_TIMEOUT` |
+
+A value of `0` means no timeout — queries can run indefinitely.
+
+**Examples:**
+
+```sql
+-- Set a 30-second timeout for the current session
+SET gizmosql.query_timeout = 30;
+
+-- Remove the timeout (unlimited)
+SET gizmosql.query_timeout = 0;
+
+-- Set a server-wide 60-second default (requires admin role)
+SET GLOBAL gizmosql.query_timeout = 60;
+```
+
+## Scope and Precedence
+
+| Scope | Who can set | Affects |
+|-------|------------|---------|
+| **Session** | Any user | Only the current connection |
+| **Global** | Admin users only | All new and existing sessions that haven't set a session-level override |
+
+Session-level settings always take precedence over the global server setting. When a session-level value is set, the server-level default is ignored for that session.
+
+## Notes
+
+- `SET GLOBAL` requires the user to have the `admin` role. Non-admin users will receive an error.
+- These commands are processed by GizmoSQL directly and are not passed to DuckDB.
+- Database GUI tools (e.g., DBeaver, DataGrip) often use separate connections for the SQL editor and the schema/metadata browser. A `SET` command executed in the SQL editor will not affect the metadata browser's connection. Use `SET GLOBAL` or server startup flags to affect all connections.

--- a/src/common/gizmosql_logging.cpp
+++ b/src/common/gizmosql_logging.cpp
@@ -427,6 +427,25 @@ void LogWithFields(arrow::util::ArrowLogLevel level,
   logger->Log(d);
 }
 
+void LogWithFieldsUnchecked(arrow::util::Logger* logger,
+                            arrow::util::ArrowLogLevel level,
+                            const char* file,
+                            int line,
+                            std::string_view msg,
+                            const FieldList& fields) {
+  // Prepend encoded KV if present
+  std::string full = EncodeFieldsForMessage(fields);
+
+  full.append(msg.data(), msg.size());
+
+  arrow::util::LogDetails d;
+  d.severity = level;
+  d.message = full;
+  d.source_location.file = file;
+  d.source_location.line = static_cast<uint32_t>(line);
+  logger->Log(d);
+}
+
 void SetInstanceId(const std::string& instance_id) {
   std::lock_guard<std::mutex> lk(G.instance_id_mu);
   G.instance_id = instance_id;

--- a/src/common/gizmosql_security.cpp
+++ b/src/common/gizmosql_security.cpp
@@ -794,7 +794,7 @@ arrow::util::ArrowLogLevel BearerAuthServerMiddlewareFactory::GetTokenLogLevel(
       logged_token_ids_.insert(token_id);
     }
 
-    return auth_log_level_;
+    return arrow::util::ArrowLogLevel::ARROW_INFO;
   }
 }
 
@@ -866,15 +866,11 @@ BearerAuthServerMiddlewareFactory::VerifyAndDecodeToken(
       }
     }
 
-    auto token_log_threshold = GetTokenLogLevel(decoded);
     // First-seen tokens display at INFO; repeat tokens display at DEBUG
-    auto token_display_level =
-        (token_log_threshold == arrow::util::ArrowLogLevel::ARROW_DEBUG)
-            ? arrow::util::ArrowLogLevel::ARROW_DEBUG
-            : arrow::util::ArrowLogLevel::ARROW_INFO;
+    auto token_display_level = GetTokenLogLevel(decoded);
 
     GIZMOSQL_LOGKV_DYNAMIC_AT(
-        token_log_threshold, token_display_level,
+        auth_log_level_, token_display_level,
         "peer=" + context.peer() + " - Bearer Token was validated successfully" +
             " - token_claims=(id=" + SafeGetTokenId(decoded) + " sub=" + decoded.get_subject() +
             " iss=" + decoded.get_issuer() + ")",

--- a/src/common/include/detail/gizmosql_logging.h
+++ b/src/common/include/detail/gizmosql_logging.h
@@ -88,6 +88,12 @@ void InitLogging(const LogConfig& cfg);
 void SetLogLevel(arrow::util::ArrowLogLevel level);
 void LogWithFields(arrow::util::ArrowLogLevel level, const char* file, int line,
                    std::string_view msg, const FieldList& fields = {});
+// Variant that skips the global logger severity check — used by DYNAMIC_AT macros
+// where a caller-supplied threshold (e.g., query_log_level) is the sole gate.
+void LogWithFieldsUnchecked(arrow::util::Logger* logger,
+                            arrow::util::ArrowLogLevel level, const char* file,
+                            int line, std::string_view msg,
+                            const FieldList& fields = {});
 std::optional<TraceCorrelationIds> GetCurrentTraceCorrelationIds();
 
 /// Set the instance ID for log correlation. Once set, this ID will be included
@@ -245,7 +251,7 @@ ScopeGuard<F> MakeScopeGuard(F f) {
   } while (0)
 
 // Dynamic-level logging with separate threshold and display severity.
-// THRESHOLD is the component's minimum level (e.g., query_log_level).
+// THRESHOLD is the component's minimum level (e.g., auth_log_level).
 // DISPLAY_SEV is the message's natural severity (e.g., INFO for routine logs).
 // The message is emitted only when DISPLAY_SEV >= both the component THRESHOLD
 // and the overall logger severity, ensuring that setting a component threshold
@@ -289,9 +295,9 @@ ScopeGuard<F> MakeScopeGuard(F f) {
   do {                                                                               \
     auto _logger_sp = ::arrow::util::LoggerRegistry::GetDefaultLogger();             \
     auto* _logger = _logger_sp.get();                                                \
-    if (_logger && (DISPLAY_SEV >= THRESHOLD) &&                                     \
-        (DISPLAY_SEV >= _logger->severity_threshold())) {                            \
-      ::gizmosql::LogWithFields(DISPLAY_SEV, __FILE__, __LINE__, MSG,                \
+    if (_logger && (DISPLAY_SEV >= THRESHOLD)) {                                     \
+      ::gizmosql::LogWithFieldsUnchecked(_logger, DISPLAY_SEV,                       \
+          __FILE__, __LINE__, MSG,                                                   \
           ::gizmosql::FieldList{SESSION_KV_FIELDS(SESSION), __VA_ARGS__});           \
     }                                                                                \
   } while (0)

--- a/src/duckdb/duckdb_server.cpp
+++ b/src/duckdb/duckdb_server.cpp
@@ -904,8 +904,11 @@ class DuckDBFlightSqlServer::Impl {
     new_session->connection_protocol = tl_request_ctx.connection_protocol.value_or("plaintext");
     new_session->catalog_access = tl_request_ctx.catalog_access.value_or(std::vector<CatalogAccessRule>{});
     new_session->connection = std::make_shared<gizmosql::TrackedDuckDBConnection>(*db_instance_);
-    new_session->query_timeout = query_timeout_;
-    new_session->query_log_level = query_log_level_;
+    // Note: query_timeout and query_log_level are intentionally left as nullopt
+    // so that sessions fall through to the server's current global values via
+    // GetQueryTimeout() and GetSessionOrServerLogLevel(). This ensures that
+    // SET GLOBAL takes effect immediately for all existing sessions that haven't
+    // set a session-level override.
 
 #ifdef GIZMOSQL_ENTERPRISE
     // Create session instrumentation if manager is available (Enterprise feature)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ enable_testing()
 # ---------------------------------------------------------
 # Core integration tests (always built)
 set(GIZMOSQL_CORE_TEST_SRCS
+        integration/test_auth_log_level.cpp
         integration/test_authentication.cpp
         integration/test_bulk_ingest.cpp
         integration/test_catalog_access.cpp
@@ -28,6 +29,7 @@ set(GIZMOSQL_CORE_TEST_SRCS
         integration/test_interactive_client.cpp
         integration/test_internal_query_log_level.cpp
         integration/test_log_level_filtering.cpp
+        integration/test_set_query_log_level.cpp
         integration/test_sqlite_backend.cpp
         integration/test_token_authorized_emails.cpp
         integration/test_tpch_benchmark.cpp

--- a/tests/integration/test_auth_log_level.cpp
+++ b/tests/integration/test_auth_log_level.cpp
@@ -1,0 +1,224 @@
+// =============================================================================
+// Test: Auth log level filtering for bearer token validation
+// Verifies that repeat bearer token validations (which display at DEBUG) are
+// correctly suppressed when auth_log_level is INFO (the default), and that
+// first-seen token validations (which display at INFO) are always emitted.
+// =============================================================================
+
+#include <gtest/gtest.h>
+
+#include <arrow/flight/client.h>
+#include <arrow/flight/sql/client.h>
+#include <arrow/table.h>
+#include <arrow/util/logger.h>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "test_server_fixture.h"
+#include "test_util.h"
+
+using arrow::util::ArrowLogLevel;
+using arrow::util::LogDetails;
+using arrow::util::Logger;
+using arrow::util::LoggerRegistry;
+using arrow::flight::sql::FlightSqlClient;
+
+namespace {
+
+// A logger that captures every message for later assertion.
+class CapturingLogger final : public Logger {
+ public:
+  struct Entry {
+    ArrowLogLevel severity;
+    std::string message;
+  };
+
+  explicit CapturingLogger(ArrowLogLevel threshold) : threshold_(threshold) {}
+
+  bool is_enabled() const override { return true; }
+  ArrowLogLevel severity_threshold() const override { return threshold_; }
+
+  void Log(const LogDetails& d) override {
+    std::lock_guard<std::mutex> lk(mu_);
+    entries_.push_back({d.severity, std::string(d.message)});
+  }
+
+  std::vector<Entry> TakeEntries() {
+    std::lock_guard<std::mutex> lk(mu_);
+    auto result = std::move(entries_);
+    entries_.clear();
+    return result;
+  }
+
+ private:
+  ArrowLogLevel threshold_;
+  mutable std::mutex mu_;
+  std::vector<Entry> entries_;
+};
+
+// Count entries matching a severity and containing a substring
+int CountEntries(const std::vector<CapturingLogger::Entry>& entries,
+                 ArrowLogLevel severity, const std::string& substr) {
+  int count = 0;
+  for (const auto& e : entries) {
+    if (e.severity == severity &&
+        e.message.find(substr) != std::string::npos) {
+      ++count;
+    }
+  }
+  return count;
+}
+
+bool HasEntryContaining(const std::vector<CapturingLogger::Entry>& entries,
+                        const std::string& substr) {
+  for (const auto& e : entries) {
+    if (e.message.find(substr) != std::string::npos) return true;
+  }
+  return false;
+}
+
+}  // namespace
+
+// =============================================================================
+// Fixture: Server with default auth_log_level=INFO
+// =============================================================================
+class AuthLogLevelFixture
+    : public gizmosql::testing::ServerTestFixture<AuthLogLevelFixture> {
+ public:
+  static gizmosql::testing::TestServerConfig GetConfig() {
+    return {
+        .database_filename = "auth_log_level_test.db",
+        .port = 31420,
+        .health_port = 31421,
+        .username = "testuser",
+        .password = "testpassword",
+        .enable_instrumentation = false,
+    };
+  }
+};
+
+template <>
+std::shared_ptr<arrow::flight::sql::FlightSqlServerBase>
+    gizmosql::testing::ServerTestFixture<AuthLogLevelFixture>::server_{};
+template <>
+std::thread
+    gizmosql::testing::ServerTestFixture<AuthLogLevelFixture>::server_thread_{};
+template <>
+std::atomic<bool>
+    gizmosql::testing::ServerTestFixture<AuthLogLevelFixture>::server_ready_{false};
+template <>
+gizmosql::testing::TestServerConfig
+    gizmosql::testing::ServerTestFixture<AuthLogLevelFixture>::config_{};
+
+// =============================================================================
+// Test: Repeat bearer token validations are suppressed at INFO auth_log_level
+//
+// The server uses auth_log_level=INFO (default). First-seen tokens are logged
+// at INFO severity, while repeat tokens are logged at DEBUG severity. With the
+// auth_log_level threshold set to INFO, repeat token logs (DEBUG) should be
+// suppressed.
+// =============================================================================
+TEST_F(AuthLogLevelFixture, RepeatBearerTokenLogsSuppressedAtInfoThreshold) {
+  ASSERT_TRUE(IsServerReady()) << "Server not ready";
+
+  // Connect and get a bearer token via Basic auth
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto location,
+      arrow::flight::Location::ForGrpcTcp("localhost", GetPort()));
+  arrow::flight::FlightClientOptions client_options;
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto client,
+      arrow::flight::FlightClient::Connect(location, client_options));
+
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto bearer,
+      client->AuthenticateBasicToken({}, GetUsername(), GetPassword()));
+
+  arrow::flight::FlightCallOptions call_options;
+  call_options.headers.push_back(bearer);
+
+  // First bearer call — this triggers first-seen token validation (INFO display)
+  // We don't capture this one; we just need the token to be "seen" by the server.
+  FlightSqlClient sql_client(std::move(client));
+  ASSERT_ARROW_OK_AND_ASSIGN(auto info1, sql_client.Execute(call_options, "SELECT 1"));
+  for (const auto& endpoint : info1->endpoints()) {
+    ASSERT_ARROW_OK_AND_ASSIGN(auto reader, sql_client.DoGet(call_options, endpoint.ticket));
+    ASSERT_ARROW_OK_AND_ASSIGN(auto table, reader->ToTable());
+  }
+
+  // Now install capturing logger and make a second call with the same bearer token.
+  // This triggers a repeat token validation which displays at DEBUG severity.
+  auto original_logger = LoggerRegistry::GetDefaultLogger();
+  auto capturing_logger = std::make_shared<CapturingLogger>(ArrowLogLevel::ARROW_DEBUG);
+  LoggerRegistry::SetDefaultLogger(capturing_logger);
+
+  ASSERT_ARROW_OK_AND_ASSIGN(auto info2, sql_client.Execute(call_options, "SELECT 2"));
+  for (const auto& endpoint : info2->endpoints()) {
+    ASSERT_ARROW_OK_AND_ASSIGN(auto reader, sql_client.DoGet(call_options, endpoint.ticket));
+    ASSERT_ARROW_OK_AND_ASSIGN(auto table, reader->ToTable());
+  }
+
+  LoggerRegistry::SetDefaultLogger(original_logger);
+
+  auto entries = capturing_logger->TakeEntries();
+
+  // Repeat bearer token validation should NOT produce DEBUG-level auth logs,
+  // because the auth_log_level threshold is INFO and DEBUG < INFO.
+  int debug_bearer_count = CountEntries(entries, ArrowLogLevel::ARROW_DEBUG,
+                                        "Bearer Token was validated successfully");
+  EXPECT_EQ(debug_bearer_count, 0)
+      << "Repeat bearer token validation (DEBUG display) should be suppressed "
+         "when auth_log_level threshold is INFO";
+}
+
+// =============================================================================
+// Test: First-seen bearer token validation IS logged at INFO threshold
+// =============================================================================
+TEST_F(AuthLogLevelFixture, FirstSeenBearerTokenLoggedAtInfoThreshold) {
+  ASSERT_TRUE(IsServerReady()) << "Server not ready";
+
+  // Connect with a fresh client to get a new bearer token
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto location,
+      arrow::flight::Location::ForGrpcTcp("localhost", GetPort()));
+  arrow::flight::FlightClientOptions client_options;
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto client,
+      arrow::flight::FlightClient::Connect(location, client_options));
+
+  // Install capturing logger BEFORE authenticating so we capture the first-seen log
+  auto original_logger = LoggerRegistry::GetDefaultLogger();
+  auto capturing_logger = std::make_shared<CapturingLogger>(ArrowLogLevel::ARROW_DEBUG);
+  LoggerRegistry::SetDefaultLogger(capturing_logger);
+
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto bearer,
+      client->AuthenticateBasicToken({}, GetUsername(), GetPassword()));
+
+  arrow::flight::FlightCallOptions call_options;
+  call_options.headers.push_back(bearer);
+
+  // Make a call — this is the first use of this bearer token
+  FlightSqlClient sql_client(std::move(client));
+  ASSERT_ARROW_OK_AND_ASSIGN(auto info, sql_client.Execute(call_options, "SELECT 1"));
+  for (const auto& endpoint : info->endpoints()) {
+    ASSERT_ARROW_OK_AND_ASSIGN(auto reader, sql_client.DoGet(call_options, endpoint.ticket));
+    ASSERT_ARROW_OK_AND_ASSIGN(auto table, reader->ToTable());
+  }
+
+  LoggerRegistry::SetDefaultLogger(original_logger);
+
+  auto entries = capturing_logger->TakeEntries();
+
+  // First-seen bearer token validation should produce an INFO-level log
+  EXPECT_TRUE(HasEntryContaining(entries, "Bearer Token was validated successfully"))
+      << "First-seen bearer token validation should be logged at INFO threshold";
+
+  // Verify it was logged at INFO severity (not DEBUG)
+  int info_bearer_count = CountEntries(entries, ArrowLogLevel::ARROW_INFO,
+                                       "Bearer Token was validated successfully");
+  EXPECT_GT(info_bearer_count, 0)
+      << "First-seen bearer token should be logged at INFO severity";
+}

--- a/tests/integration/test_ducklake.cpp
+++ b/tests/integration/test_ducklake.cpp
@@ -248,6 +248,23 @@ TEST_F(DuckLakeServerFixture, DuckLakeSetupAndQuery) {
   result = RunQuery(sql_client, call_options, create_pg_secret);
   ASSERT_TRUE(result.success) << "Failed to create postgres secret: " << result.error_message;
 
+  // Step 2b: Reset DuckLake metadata in Postgres to avoid snapshot ID collisions
+  // from previous test runs. Drop and recreate the public schema to clear all
+  // DuckLake metadata tables (ducklake_snapshot, ducklake_data_file, etc.).
+  std::cerr << "Resetting DuckLake metadata in PostgreSQL..." << std::endl;
+  result = RunQuery(sql_client, call_options, R"(
+    ATTACH 'dbname=ducklake_catalog host=localhost port=5432 user=postgres password=testpassword'
+      AS pg_cleanup (TYPE postgres);
+  )");
+  if (result.success) {
+    RunQuery(sql_client, call_options,
+             "DROP SCHEMA IF EXISTS pg_cleanup.public CASCADE;");
+    RunQuery(sql_client, call_options,
+             "CREATE SCHEMA pg_cleanup.public;");
+    RunQuery(sql_client, call_options, "DETACH pg_cleanup;");
+    std::cerr << "  DuckLake metadata reset complete" << std::endl;
+  }
+
   // Step 3: Create DuckLake secret
   std::cerr << "Creating DuckLake secret..." << std::endl;
   std::string create_ducklake_secret = R"(

--- a/tests/integration/test_log_level_filtering.cpp
+++ b/tests/integration/test_log_level_filtering.cpp
@@ -263,17 +263,20 @@ TEST_F(SessionLogLevelFilteringTest,
 }
 
 TEST_F(SessionLogLevelFilteringTest,
-       SessionDynamic_ConvenienceWrapperSuppressesWhenOverallThresholdHigher) {
-  // Overall logger threshold is ERROR
+       SessionDynamic_ConvenienceWrapperNotSuppressedByOverallThreshold) {
+  // Overall logger threshold is ERROR, but the DYNAMIC macro uses the
+  // component threshold as the sole gate — global threshold is ignored.
   auto logger = InstallCapturingLogger(ArrowLogLevel::ARROW_ERROR);
 
   GIZMOSQL_LOGKV_SESSION_DYNAMIC(
-      ArrowLogLevel::ARROW_INFO, session_, "Should be suppressed",
+      ArrowLogLevel::ARROW_INFO, session_, "Should NOT be suppressed",
       {"kind", "test"}, {"status", "ok"});
 
   auto entries = logger->TakeEntries();
-  EXPECT_TRUE(entries.empty())
-      << "INFO message should be suppressed when overall threshold is ERROR";
+  ASSERT_EQ(entries.size(), 1u)
+      << "INFO message should pass when component threshold is INFO, "
+         "regardless of overall logger threshold";
+  EXPECT_EQ(entries[0].severity, ArrowLogLevel::ARROW_INFO);
 }
 
 // =============================================================================

--- a/tests/integration/test_set_query_log_level.cpp
+++ b/tests/integration/test_set_query_log_level.cpp
@@ -1,0 +1,345 @@
+// =============================================================================
+// Test: SET gizmosql.query_log_level — session-level dynamic log level changes
+// Verifies that SET gizmosql.query_log_level dynamically changes the query log
+// threshold within a session. Normal queries (SELECT) log at INFO and should
+// appear at both INFO and DEBUG thresholds. Internal queries (DoGetTables) log
+// at DEBUG and should only appear when the threshold is lowered to DEBUG.
+// =============================================================================
+
+#include <gtest/gtest.h>
+
+#include <arrow/array.h>
+#include <arrow/flight/client.h>
+#include <arrow/flight/sql/client.h>
+#include <arrow/table.h>
+#include <arrow/util/logger.h>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "test_server_fixture.h"
+#include "test_util.h"
+
+using arrow::util::ArrowLogLevel;
+using arrow::util::LogDetails;
+using arrow::util::Logger;
+using arrow::util::LoggerRegistry;
+using arrow::flight::sql::FlightSqlClient;
+
+namespace {
+
+// A logger that captures every message for later assertion.
+class CapturingLogger final : public Logger {
+ public:
+  struct Entry {
+    ArrowLogLevel severity;
+    std::string message;
+  };
+
+  explicit CapturingLogger(ArrowLogLevel threshold) : threshold_(threshold) {}
+
+  bool is_enabled() const override { return true; }
+  ArrowLogLevel severity_threshold() const override { return threshold_; }
+
+  void Log(const LogDetails& d) override {
+    std::lock_guard<std::mutex> lk(mu_);
+    entries_.push_back({d.severity, std::string(d.message)});
+  }
+
+  std::vector<Entry> TakeEntries() {
+    std::lock_guard<std::mutex> lk(mu_);
+    auto result = std::move(entries_);
+    entries_.clear();
+    return result;
+  }
+
+ private:
+  ArrowLogLevel threshold_;
+  mutable std::mutex mu_;
+  std::vector<Entry> entries_;
+};
+
+// Helper: find entries containing a substring
+bool HasEntryContaining(const std::vector<CapturingLogger::Entry>& entries,
+                        const std::string& substr) {
+  for (const auto& e : entries) {
+    if (e.message.find(substr) != std::string::npos) return true;
+  }
+  return false;
+}
+
+}  // namespace
+
+// =============================================================================
+// Fixture: Server with query_log_level=INFO (default), print_queries=true
+// The test will use SET to dynamically change query_log_level within a session.
+// =============================================================================
+class SetQueryLogLevelFixture
+    : public gizmosql::testing::ServerTestFixture<SetQueryLogLevelFixture> {
+ public:
+  static gizmosql::testing::TestServerConfig GetConfig() {
+    return {
+        .database_filename = "set_query_log_level_test.db",
+        .port = 31410,
+        .health_port = 31411,
+        .username = "testuser",
+        .password = "testpassword",
+        .enable_instrumentation = false,
+        .init_sql_commands = "CREATE TABLE set_log_test (id INTEGER, name VARCHAR);",
+        .print_queries = true,
+        .query_log_level = ArrowLogLevel::ARROW_INFO,
+    };
+  }
+};
+
+template <>
+std::shared_ptr<arrow::flight::sql::FlightSqlServerBase>
+    gizmosql::testing::ServerTestFixture<SetQueryLogLevelFixture>::server_{};
+template <>
+std::thread
+    gizmosql::testing::ServerTestFixture<SetQueryLogLevelFixture>::server_thread_{};
+template <>
+std::atomic<bool>
+    gizmosql::testing::ServerTestFixture<SetQueryLogLevelFixture>::server_ready_{false};
+template <>
+gizmosql::testing::TestServerConfig
+    gizmosql::testing::ServerTestFixture<SetQueryLogLevelFixture>::config_{};
+
+// =============================================================================
+// Helper: Create an authenticated FlightSqlClient
+// =============================================================================
+struct AuthenticatedClient {
+  std::unique_ptr<arrow::flight::FlightClient> flight_client;
+  std::unique_ptr<FlightSqlClient> sql_client;
+  arrow::flight::FlightCallOptions call_options;
+};
+
+static arrow::Result<AuthenticatedClient> MakeClient(
+    int port, const std::string& username, const std::string& password) {
+  AuthenticatedClient ac;
+  ARROW_ASSIGN_OR_RAISE(auto location,
+                         arrow::flight::Location::ForGrpcTcp("localhost", port));
+  arrow::flight::FlightClientOptions client_options;
+  ARROW_ASSIGN_OR_RAISE(ac.flight_client,
+                         arrow::flight::FlightClient::Connect(location, client_options));
+
+  ARROW_ASSIGN_OR_RAISE(auto bearer,
+                         ac.flight_client->AuthenticateBasicToken({}, username, password));
+  ac.call_options.headers.push_back(bearer);
+
+  ac.sql_client = std::make_unique<FlightSqlClient>(std::move(ac.flight_client));
+  return ac;
+}
+
+// Helper: Execute a SELECT query and read all results into a Table
+static arrow::Result<std::shared_ptr<arrow::Table>> ExecuteSelect(
+    FlightSqlClient& client, arrow::flight::FlightCallOptions& opts,
+    const std::string& sql) {
+  ARROW_ASSIGN_OR_RAISE(auto info, client.Execute(opts, sql));
+  std::shared_ptr<arrow::Table> combined;
+  for (const auto& endpoint : info->endpoints()) {
+    ARROW_ASSIGN_OR_RAISE(auto reader, client.DoGet(opts, endpoint.ticket));
+    ARROW_ASSIGN_OR_RAISE(combined, reader->ToTable());
+  }
+  return combined;
+}
+
+// Helper: Execute an update/SET command
+static arrow::Result<int64_t> ExecuteUpdate(
+    FlightSqlClient& client, arrow::flight::FlightCallOptions& opts,
+    const std::string& sql) {
+  return client.ExecuteUpdate(opts, sql);
+}
+
+// Helper: Call GetTables and read results
+static arrow::Result<std::shared_ptr<arrow::Table>> CallGetTables(
+    FlightSqlClient& client, arrow::flight::FlightCallOptions& opts) {
+  ARROW_ASSIGN_OR_RAISE(
+      auto info,
+      client.GetTables(opts,
+                       /*catalog=*/nullptr,
+                       /*db_schema_filter_pattern=*/nullptr,
+                       /*table_filter_pattern=*/nullptr,
+                       /*include_schema=*/false,
+                       /*table_types=*/nullptr));
+
+  std::shared_ptr<arrow::Table> combined;
+  for (const auto& endpoint : info->endpoints()) {
+    ARROW_ASSIGN_OR_RAISE(auto reader, client.DoGet(opts, endpoint.ticket));
+    ARROW_ASSIGN_OR_RAISE(combined, reader->ToTable());
+  }
+  return combined;
+}
+
+// =============================================================================
+// Test: At default INFO threshold, normal SELECT is logged but DoGetTables is not.
+// After SET gizmosql.query_log_level = DEBUG, both are logged.
+// =============================================================================
+TEST_F(SetQueryLogLevelFixture, SessionSetChangesLogThreshold) {
+  ASSERT_TRUE(IsServerReady()) << "Server not ready";
+
+  // Connect and authenticate
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto ac, MakeClient(GetPort(), GetUsername(), GetPassword()));
+
+  auto original_logger = LoggerRegistry::GetDefaultLogger();
+  auto capturing_logger = std::make_shared<CapturingLogger>(ArrowLogLevel::ARROW_DEBUG);
+
+  // ---- Phase 1: Default INFO threshold ----
+  // Normal SELECT should be logged, DoGetTables should NOT be logged
+
+  LoggerRegistry::SetDefaultLogger(capturing_logger);
+
+  // Execute a normal SELECT (logs at INFO severity)
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto select_result,
+      ExecuteSelect(*ac.sql_client, ac.call_options,
+                    "SELECT 1 AS test_value"));
+
+  auto phase1_entries = capturing_logger->TakeEntries();
+
+  // Normal query logs should be present (is_internal=false, logged at INFO)
+  EXPECT_TRUE(HasEntryContaining(phase1_entries, "\"is_internal\":\"false\""))
+      << "Normal SELECT query should be logged at INFO threshold";
+
+  // Now call DoGetTables (logs at DEBUG severity)
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto tables1, CallGetTables(*ac.sql_client, ac.call_options));
+  ASSERT_GT(tables1->num_rows(), 0) << "GetTables should return results";
+
+  auto phase1_get_tables_entries = capturing_logger->TakeEntries();
+
+  // Internal query logs should NOT be present (DEBUG < INFO threshold)
+  EXPECT_FALSE(HasEntryContaining(phase1_get_tables_entries, "\"is_internal\":\"true\""))
+      << "Internal DoGetTables query should NOT be logged at default INFO threshold";
+
+  LoggerRegistry::SetDefaultLogger(original_logger);
+
+  // ---- Phase 2: SET gizmosql.query_log_level = DEBUG ----
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto set_result,
+      ExecuteSelect(*ac.sql_client, ac.call_options,
+                    "SET gizmosql.query_log_level = DEBUG"));
+
+  // Drain any log entries from the SET command itself
+  LoggerRegistry::SetDefaultLogger(capturing_logger);
+  capturing_logger->TakeEntries();
+
+  // Execute a normal SELECT again (should still be logged)
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto select_result2,
+      ExecuteSelect(*ac.sql_client, ac.call_options,
+                    "SELECT 2 AS test_value"));
+
+  auto phase2_select_entries = capturing_logger->TakeEntries();
+
+  EXPECT_TRUE(HasEntryContaining(phase2_select_entries, "\"is_internal\":\"false\""))
+      << "Normal SELECT query should still be logged at DEBUG threshold";
+
+  // Now call DoGetTables again — should be logged this time
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto tables2, CallGetTables(*ac.sql_client, ac.call_options));
+  ASSERT_GT(tables2->num_rows(), 0) << "GetTables should return results";
+
+  auto phase2_get_tables_entries = capturing_logger->TakeEntries();
+
+  // Internal query logs SHOULD be present now (DEBUG >= DEBUG threshold)
+  bool found_internal = HasEntryContaining(phase2_get_tables_entries,
+                                           "\"is_internal\":\"true\"");
+  EXPECT_TRUE(found_internal)
+      << "Internal DoGetTables query SHOULD be logged after "
+         "SET gizmosql.query_log_level = DEBUG";
+
+  // Verify internal logs are at DEBUG severity
+  if (found_internal) {
+    for (const auto& entry : phase2_get_tables_entries) {
+      if (entry.message.find("\"is_internal\":\"true\"") != std::string::npos) {
+        EXPECT_EQ(entry.severity, ArrowLogLevel::ARROW_DEBUG)
+            << "Internal query logs should be emitted at DEBUG severity";
+      }
+    }
+  }
+
+  LoggerRegistry::SetDefaultLogger(original_logger);
+}
+
+// =============================================================================
+// Test: SET GLOBAL propagates immediately to existing sessions
+//
+// 1. Client A connects (session created with default INFO threshold)
+// 2. Client B connects and runs SET GLOBAL gizmosql.query_log_level = DEBUG
+// 3. Client A (without reconnecting) calls DoGetTables
+// 4. Internal query logs should appear — proving the global change propagated
+// 5. Client B resets it back: SET GLOBAL gizmosql.query_log_level = INFO
+// 6. Client A calls DoGetTables again — internal logs should be suppressed
+// =============================================================================
+TEST_F(SetQueryLogLevelFixture, SetGlobalPropagatesImmediatelyToExistingSessions) {
+  ASSERT_TRUE(IsServerReady()) << "Server not ready";
+
+  // Client A — connects first (session gets nullopt query_log_level, falls through
+  // to server global which is INFO)
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto clientA, MakeClient(GetPort(), GetUsername(), GetPassword()));
+
+  // Client B — will issue SET GLOBAL
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto clientB, MakeClient(GetPort(), GetUsername(), GetPassword()));
+
+  auto original_logger = LoggerRegistry::GetDefaultLogger();
+  auto capturing_logger = std::make_shared<CapturingLogger>(ArrowLogLevel::ARROW_DEBUG);
+
+  // ---- Phase 1: Before SET GLOBAL, client A's DoGetTables should NOT log ----
+  LoggerRegistry::SetDefaultLogger(capturing_logger);
+
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto tables1, CallGetTables(*clientA.sql_client, clientA.call_options));
+  ASSERT_GT(tables1->num_rows(), 0);
+
+  auto phase1_entries = capturing_logger->TakeEntries();
+  EXPECT_FALSE(HasEntryContaining(phase1_entries, "\"is_internal\":\"true\""))
+      << "Before SET GLOBAL, internal queries should be suppressed at INFO threshold";
+
+  LoggerRegistry::SetDefaultLogger(original_logger);
+
+  // ---- Phase 2: Client B runs SET GLOBAL gizmosql.query_log_level = DEBUG ----
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto set_result,
+      ExecuteSelect(*clientB.sql_client, clientB.call_options,
+                    "SET GLOBAL gizmosql.query_log_level = DEBUG"));
+
+  // ---- Phase 3: Client A (no reconnect!) calls DoGetTables — should now log ----
+  LoggerRegistry::SetDefaultLogger(capturing_logger);
+  capturing_logger->TakeEntries();  // drain
+
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto tables2, CallGetTables(*clientA.sql_client, clientA.call_options));
+  ASSERT_GT(tables2->num_rows(), 0);
+
+  auto phase2_entries = capturing_logger->TakeEntries();
+  EXPECT_TRUE(HasEntryContaining(phase2_entries, "\"is_internal\":\"true\""))
+      << "After SET GLOBAL DEBUG, existing session should immediately see "
+         "internal query logs without reconnecting";
+
+  LoggerRegistry::SetDefaultLogger(original_logger);
+
+  // ---- Phase 4: Client B resets global back to INFO ----
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto reset_result,
+      ExecuteSelect(*clientB.sql_client, clientB.call_options,
+                    "SET GLOBAL gizmosql.query_log_level = INFO"));
+
+  // ---- Phase 5: Client A calls DoGetTables again — should be suppressed ----
+  LoggerRegistry::SetDefaultLogger(capturing_logger);
+  capturing_logger->TakeEntries();  // drain
+
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto tables3, CallGetTables(*clientA.sql_client, clientA.call_options));
+  ASSERT_GT(tables3->num_rows(), 0);
+
+  auto phase3_entries = capturing_logger->TakeEntries();
+  EXPECT_FALSE(HasEntryContaining(phase3_entries, "\"is_internal\":\"true\""))
+      << "After SET GLOBAL INFO, internal queries should be suppressed again";
+
+  LoggerRegistry::SetDefaultLogger(original_logger);
+}


### PR DESCRIPTION
## Summary

- **`query_log_level` independent of `--log-level`**: `SET gizmosql.query_log_level = DEBUG` now works without requiring `--log-level debug`. The `GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT` macro now uses `LogWithFieldsUnchecked()` to bypass the global Arrow logger's severity threshold, making `query_log_level` the sole gate for query log messages.
- **`SET GLOBAL` propagates immediately**: Session `query_log_level` and `query_timeout` are no longer baked in at session creation. They default to `nullopt` and fall through to the server's current global value, so `SET GLOBAL` takes effect for all existing sessions without requiring a reconnect.
- **Auth log level threshold fix**: Bearer token validation now uses `auth_log_level_` as the threshold (consistent with all other auth log sites). `GetTokenLogLevel()` returns only the display severity (`INFO` for first-seen, `DEBUG` for repeat tokens) — it no longer returns `auth_log_level_`.
- **SET commands documentation**: New `docs/set_commands.md` covering `gizmosql.query_log_level` and `gizmosql.query_timeout` with session/global scope, valid values, and admin restrictions.
- **CLAUDE.md architecture docs**: Added "Component Log Level Architecture" section documenting the three independent log level controls, macro usage rules, and 5 key invariants that must not regress.

## Test plan

- [x] `LogLevelFilteringTest` (7 tests) — Macro threshold behavior for `GIZMOSQL_LOGKV_DYNAMIC_AT`
- [x] `SessionLogLevelFilteringTest` (7 tests) — Macro threshold behavior for `GIZMOSQL_LOGKV_SESSION_DYNAMIC_AT`
- [x] `SetQueryLogLevelFixture.SessionSetChangesLogThreshold` — Session-level SET dynamically changes threshold (SELECT logged at both levels, DoGetTables only at DEBUG)
- [x] `SetQueryLogLevelFixture.SetGlobalPropagatesImmediatelyToExistingSessions` — SET GLOBAL propagates to existing sessions without reconnect, and reverting global restores suppression
- [x] `AuthLogLevelFixture.RepeatBearerTokenLogsSuppressedAtInfoThreshold` — Repeat bearer tokens (DEBUG display) suppressed at INFO auth_log_level
- [x] `AuthLogLevelFixture.FirstSeenBearerTokenLoggedAtInfoThreshold` — First-seen bearer tokens logged at INFO severity
- [x] All 20 log-related tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)