### PR TITLE
Fix adbc_ingest with temporary=True failing on repeat calls (#158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to GizmoSQL will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Bulk ingest with `temporary=True` (issue [#158](https://github.com/gizmodata/gizmosql/issues/158))**: Repeated `adbc_ingest(..., temporary=True)` calls (or any Flight SQL `CommandStatementIngest` with `temporary=true`) no longer fail with `Catalog Error: Table with name "..." already exists!` (for `create_append`/`replace`) or `Table: "..." does not exist` (for `create` then `append`). The server's table-existence check previously only consulted the current database catalog, so temporary tables — which DuckDB stores in the implicit `temp.main` catalog — were invisible to the lookup. `TableExists()` now scopes to `temp.main` when the ingest is temporary. Thanks again to @fromm1990 for the report and reproducer.
+
 ## [1.21.2] - 2026-04-21
 
 ### Fixed

--- a/src/duckdb/duckdb_server.cpp
+++ b/src/duckdb/duckdb_server.cpp
@@ -296,7 +296,7 @@ std::string QuoteIdent(const std::string& name) {
 Result<bool> TableExists(duckdb::Connection& conn,
                          const std::optional<std::string>& catalog_name,
                          const std::optional<std::string>& schema_name,
-                         const std::string& table_name) {
+                         const std::string& table_name, bool is_temp = false) {
   duckdb::vector<duckdb::Value> bind_parameters;
 
   std::string sql =
@@ -304,18 +304,25 @@ Result<bool> TableExists(duckdb::Connection& conn,
       "FROM information_schema.tables "
       "WHERE 1 = 1 ";
 
-  if (catalog_name.has_value()) {
-    sql += "AND table_catalog = ? ";
-    bind_parameters.emplace_back(catalog_name.value());
+  // Temporary tables live in the implicit `temp.main` catalog/schema in DuckDB,
+  // not in CURRENT_DATABASE()/CURRENT_SCHEMA(). When the caller indicates the
+  // target is temporary, scope the lookup there explicitly.
+  if (is_temp) {
+    sql += "AND table_catalog = 'temp' AND table_schema = 'main' ";
   } else {
-    sql += "AND table_catalog = CURRENT_DATABASE() ";
-  }
+    if (catalog_name.has_value()) {
+      sql += "AND table_catalog = ? ";
+      bind_parameters.emplace_back(catalog_name.value());
+    } else {
+      sql += "AND table_catalog = CURRENT_DATABASE() ";
+    }
 
-  if (schema_name.has_value()) {
-    sql += "AND table_schema = ? ";
-    bind_parameters.emplace_back(schema_name.value());
-  } else {
-    sql += "AND table_schema = CURRENT_SCHEMA() ";
+    if (schema_name.has_value()) {
+      sql += "AND table_schema = ? ";
+      bind_parameters.emplace_back(schema_name.value());
+    } else {
+      sql += "AND table_schema = CURRENT_SCHEMA() ";
+    }
   }
 
   sql +=
@@ -1647,7 +1654,8 @@ class DuckDBFlightSqlServer::Impl {
     {
       ARROW_ASSIGN_OR_RAISE(target_table_exists,
                             TableExists(client_session->connection->Get(), command.catalog,
-                                        command.schema, command.table));
+                                        command.schema, command.table,
+                                        command.temporary));
     }
 
     using ExistsOpt = sql::TableDefinitionOptionsTableExistsOption;

--- a/tests/integration/test_bulk_ingest.cpp
+++ b/tests/integration/test_bulk_ingest.cpp
@@ -189,3 +189,87 @@ TEST_F(BulkIngestServerFixture, ExecuteIngestInsideOpenTransaction) {
   // Commit the outer transaction — rows should now be visible.
   ASSERT_ARROW_OK(sql_client.Commit(call_options, transaction));
 }
+
+// Regression test for https://github.com/gizmodata/gizmosql/issues/158
+// Repeated ingests with temporary=true must not fail with "already exists".
+// Previously, TableExists() only consulted CURRENT_DATABASE(), missing tables
+// in DuckDB's implicit `temp` catalog, so the server treated the temp table
+// as non-existent on subsequent calls and tried to CREATE it again.
+TEST_F(BulkIngestServerFixture, ExecuteIngestTemporaryRepeatable) {
+  ASSERT_TRUE(IsServerReady()) << "Server not ready";
+
+  arrow::flight::FlightClientOptions options;
+  ASSERT_ARROW_OK_AND_ASSIGN(auto location,
+                             arrow::flight::Location::ForGrpcTcp("localhost", GetPort()));
+  ASSERT_ARROW_OK_AND_ASSIGN(auto client,
+                             arrow::flight::FlightClient::Connect(location, options));
+
+  arrow::flight::FlightCallOptions call_options;
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto bearer, client->AuthenticateBasicToken({}, GetUsername(), GetPassword()));
+  call_options.headers.push_back(bearer);
+
+  arrow::flight::sql::FlightSqlClient sql_client(std::move(client));
+
+  // Case 1: create_append twice (kCreate + kAppend)
+  {
+    TableDefinitionOptions opts;
+    opts.if_not_exist = TableDefinitionOptionsTableNotExistOption::kCreate;
+    opts.if_exists = TableDefinitionOptionsTableExistsOption::kAppend;
+
+    for (int i = 0; i < 2; ++i) {
+      auto reader = MakeTestBatches();
+      auto maybe_rows = sql_client.ExecuteIngest(
+          call_options, reader, opts, "temp_create_append", std::nullopt,
+          std::nullopt, true /* temporary */, arrow::flight::sql::no_transaction(), {});
+      ASSERT_TRUE(maybe_rows.ok())
+          << "temp create_append iter " << i << ": " << maybe_rows.status().ToString();
+      ASSERT_EQ(*maybe_rows, 3);
+    }
+  }
+
+  // Case 2: replace twice (kCreate + kReplace)
+  {
+    TableDefinitionOptions opts;
+    opts.if_not_exist = TableDefinitionOptionsTableNotExistOption::kCreate;
+    opts.if_exists = TableDefinitionOptionsTableExistsOption::kReplace;
+
+    for (int i = 0; i < 2; ++i) {
+      auto reader = MakeTestBatches();
+      auto maybe_rows = sql_client.ExecuteIngest(
+          call_options, reader, opts, "temp_replace", std::nullopt, std::nullopt,
+          true /* temporary */, arrow::flight::sql::no_transaction(), {});
+      ASSERT_TRUE(maybe_rows.ok())
+          << "temp replace iter " << i << ": " << maybe_rows.status().ToString();
+      ASSERT_EQ(*maybe_rows, 3);
+    }
+  }
+
+  // Case 3: create then append (kCreate+kFail, then kFail+kAppend)
+  {
+    {
+      TableDefinitionOptions create_opts;
+      create_opts.if_not_exist = TableDefinitionOptionsTableNotExistOption::kCreate;
+      create_opts.if_exists = TableDefinitionOptionsTableExistsOption::kFail;
+      auto reader = MakeTestBatches();
+      auto maybe_rows = sql_client.ExecuteIngest(
+          call_options, reader, create_opts, "temp_then_append", std::nullopt,
+          std::nullopt, true /* temporary */, arrow::flight::sql::no_transaction(), {});
+      ASSERT_TRUE(maybe_rows.ok())
+          << "temp create: " << maybe_rows.status().ToString();
+      ASSERT_EQ(*maybe_rows, 3);
+    }
+    {
+      TableDefinitionOptions append_opts;
+      append_opts.if_not_exist = TableDefinitionOptionsTableNotExistOption::kFail;
+      append_opts.if_exists = TableDefinitionOptionsTableExistsOption::kAppend;
+      auto reader = MakeTestBatches();
+      auto maybe_rows = sql_client.ExecuteIngest(
+          call_options, reader, append_opts, "temp_then_append", std::nullopt,
+          std::nullopt, true /* temporary */, arrow::flight::sql::no_transaction(), {});
+      ASSERT_TRUE(maybe_rows.ok())
+          << "temp append to existing: " << maybe_rows.status().ToString();
+      ASSERT_EQ(*maybe_rows, 3);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #158 — repeated `adbc_ingest(..., temporary=True)` calls fail with `Catalog Error: Table with name "..." already exists!` (for `create_append`/`replace`) or `Table: "..." does not exist` (for `create` then `append`).

**Root cause:** `TableExists()` in `src/duckdb/duckdb_server.cpp` queried `information_schema.tables` filtered by `CURRENT_DATABASE()` / `CURRENT_SCHEMA()`. DuckDB stores temporary tables in the implicit `temp.main` catalog, so they were invisible to the lookup. On a second ingest with `temporary=True` the server concluded the table was missing and re-issued `CREATE TEMPORARY TABLE`, which DuckDB then rejected.

**Fix:** Added an `is_temp` parameter to `TableExists()` that scopes the lookup to `temp.main` when set. `DoPutCommandStatementIngest` now passes `command.temporary` through.

**Test:** New regression test `BulkIngestServerFixture.ExecuteIngestTemporaryRepeatable` covering all three failing combinations from the issue (`create_append` x2, `replace` x2, `create` then `append`).

## Test plan

- [x] `ninja gizmosql_integration_tests` builds clean
- [x] `./tests/gizmosql_integration_tests --gtest_filter="BulkIngestServerFixture.*"` — 3/3 pass
- [ ] Verify reproducer from #158 (Python + adbc-driver-gizmosql) now succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)