### PR TITLE
client+docs: refuse --tls-skip-verify with mTLS, document why

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Client now refuses `--tls-skip-verify` together with `--mtls-cert`/`--mtls-key`.** Arrow Flight's gRPC transport silently drops the client certificate when `disable_server_verification` is set (it routes through `TlsChannelCredentialsOptions`, which doesn't read `cert_chain`/`private_key`), so the server rejected the handshake with a cryptic `peer did not return a certificate`. The client now errors out up-front with an actionable message pointing users at `--tls-roots`.
+
+### Documentation
+
+- **`docs/security.md` and `docs/client.md`**: documented the `--tls-skip-verify` + mTLS incompatibility, including the self-signed-cert workaround (`--tls-roots cert.pem` works because the cert is its own CA).
+
 ## [1.22.4] - 2026-04-27
 
 ### Fixed

--- a/docs/client.md
+++ b/docs/client.md
@@ -115,6 +115,8 @@ gizmosql_client --host my-server.example.com --username admin \
   --mtls-cert /path/to/client.crt --mtls-key /path/to/client.key
 ```
 
+> **`--tls-skip-verify` cannot be combined with `--mtls-cert`/`--mtls-key`.** Arrow Flight's underlying gRPC transport drops the client certificate when server verification is disabled, so the server rejects the handshake. The client refuses this combination at startup. Use `--tls-roots <ca-or-self-signed-cert>.pem` to trust the server's certificate properly. For a self-signed server cert (e.g. produced by `openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -nodes -subj "/CN=localhost"`), pass `cert.pem` directly to `--tls-roots` — it acts as its own CA.
+
 ## OAuth / SSO Authentication
 
 For servers configured with [OAuth/SSO](oauth_sso_setup.md), use `--auth-type external` to authenticate via browser-based login:

--- a/docs/security.md
+++ b/docs/security.md
@@ -150,6 +150,8 @@ openssl x509 -req -in client.csr -CA client-ca.pem -CAkey client-ca-key.pem \
 
 The server's `--mtls-ca-cert-filename` should point to the CA that signed your client certificates. The client's identity (the `CN` field) is tracked in the session context for audit logging.
 
+> **Note:** `--tls-skip-verify` is **not compatible** with mTLS on the client side. Arrow Flight's TLS implementation drops the client certificate when server verification is disabled, so the server will reject the handshake with `peer did not return a certificate`. The GizmoSQL client refuses this combination at startup and tells you to either trust the server's cert via `--tls-roots <ca-or-self-signed-cert>.pem` or use a CA-signed server certificate. For local self-signed setups (e.g. `openssl req -x509 ... -out cert.pem`), pass the server's `cert.pem` directly to `--tls-roots` — it acts as its own CA.
+
 ---
 
 ## Layer 3: Authentication

--- a/src/client/flight_connection.cpp
+++ b/src/client/flight_connection.cpp
@@ -137,6 +137,23 @@ void FlightConnection::SendCancelToServer() {
 arrow::Status FlightConnection::Connect(const ClientConfig& config) {
   Disconnect();
 
+  // --tls-skip-verify is incompatible with mTLS. Arrow Flight's gRPC
+  // transport silently drops options.cert_chain/private_key when
+  // disable_server_verification is true (it routes through
+  // TlsChannelCredentialsOptions, which doesn't read those fields), so
+  // the server sees a TLS handshake with no client cert and rejects it
+  // with "peer did not return a certificate". Refuse the combination
+  // up-front rather than letting the user hit a cryptic gRPC error.
+  if (config.tls_skip_verify && !config.mtls_cert.empty()) {
+    return arrow::Status::Invalid(
+        "--tls-skip-verify cannot be combined with --mtls-cert/--mtls-key. "
+        "Arrow Flight drops the client certificate when server verification "
+        "is disabled. Use --tls-roots <ca-or-self-signed-cert>.pem to trust "
+        "the server's certificate properly. For a self-signed server cert "
+        "(e.g. produced by `openssl req -x509 ... -out cert.pem`), pass "
+        "cert.pem directly to --tls-roots — it acts as its own CA.");
+  }
+
   ARROW_ASSIGN_OR_RAISE(
       auto location,
       config.use_tls

--- a/tests/integration/test_interactive_client.cpp
+++ b/tests/integration/test_interactive_client.cpp
@@ -105,6 +105,50 @@ TEST_F(InteractiveClientFixture, ConnectWithValidCredentials) {
   ASSERT_TRUE(conn.IsConnected());
 }
 
+// --tls-skip-verify is incompatible with mTLS: Arrow Flight's gRPC transport
+// silently drops options.cert_chain/private_key when disable_server_verification
+// is set, so the server rejects the handshake with the cryptic "peer did not
+// return a certificate". FlightConnection::Connect must refuse the combination
+// up-front with an actionable message — verified here without needing a real
+// server, since the check fires before any network I/O.
+TEST(FlightConnectionConfig, TlsSkipVerifyWithMtlsCertIsRejected) {
+  ClientConfig config;
+  config.host = "localhost";
+  config.port = 31337;
+  config.use_tls = true;
+  config.tls_skip_verify = true;
+  config.mtls_cert = "/tmp/does-not-need-to-exist.crt";
+  config.mtls_key = "/tmp/does-not-need-to-exist.key";
+
+  FlightConnection conn;
+  auto status = conn.Connect(config);
+  ASSERT_FALSE(status.ok())
+      << "Should reject --tls-skip-verify combined with --mtls-cert";
+  EXPECT_TRUE(status.IsInvalid())
+      << "Expected Invalid status, got: " << status.ToString();
+  // The error must point users toward --tls-roots — that's the actionable bit.
+  EXPECT_NE(status.message().find("--tls-roots"), std::string::npos)
+      << "Error message should reference --tls-roots: " << status.message();
+}
+
+// Sanity check: --tls-skip-verify alone (no mTLS) must still be permitted —
+// the validation should only fire when both are present.
+TEST(FlightConnectionConfig, TlsSkipVerifyAloneIsPermittedAtConfigCheck) {
+  ClientConfig config;
+  config.host = "127.0.0.1";
+  config.port = 1;  // unreachable port — Connect will fail at network step
+  config.use_tls = true;
+  config.tls_skip_verify = true;
+  // No mtls_cert / mtls_key set.
+
+  FlightConnection conn;
+  auto status = conn.Connect(config);
+  // We expect it to fail (network), but NOT with the validation error.
+  EXPECT_EQ(status.message().find("--tls-skip-verify cannot be combined"),
+            std::string::npos)
+      << "Validation should not fire without mTLS flags: " << status.message();
+}
+
 TEST_F(InteractiveClientFixture, ConnectWithInvalidCredentials) {
   ASSERT_TRUE(IsServerReady()) << "Server not ready";
   ClientConfig config;


### PR DESCRIPTION
## Summary

When a user passes `--tls-skip-verify` together with `--mtls-cert`/`--mtls-key`, Arrow Flight's gRPC transport silently drops the client certificate (it routes through `TlsChannelCredentialsOptions`, which doesn't read `cert_chain`/`private_key` — see `arrow/cpp/src/arrow/flight/transport/grpc/grpc_client.cc` around line 697). The server then rejects the handshake with the cryptic `peer did not return a certificate`, which is impossible to diagnose from the client side.

This PR:
1. Adds an up-front validation in `FlightConnection::Connect` that refuses the combination with an actionable error pointing users to `--tls-roots` (and notes that a self-signed server cert can be used as its own CA).
2. Documents the incompatibility in `docs/security.md` and `docs/client.md`, including the self-signed-cert workaround.
3. Two new gtest cases verify (a) the validation fires with the right `Invalid` status mentioning `--tls-roots`, and (b) `--tls-skip-verify` *alone* (no mTLS) still works as before. Both run without a server (~3ms total).

## Test plan

- [x] `FlightConnectionConfig.TlsSkipVerifyWithMtlsCertIsRejected` passes locally
- [x] `FlightConnectionConfig.TlsSkipVerifyAloneIsPermittedAtConfigCheck` passes locally
- [x] Manual repro: client now errors out immediately with the `--tls-roots` hint instead of hanging on the gRPC handshake
- [ ] CI green on all platforms (macOS, Linux amd64+arm64, Windows, iOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
