### PR TITLE
Flight SQL metadata: emit TYPE_NAME, add --max-metadata-size (v1.23.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.23.0] - 2026-05-06
+
+### Added
+
+- **`--max-metadata-size` / `GIZMOSQL_MAX_METADATA_SIZE`.** New server option exposing gRPC's `GRPC_ARG_MAX_METADATA_SIZE`. gRPC's default of ~8 KB rejects calls whose total HTTP/2 header list exceeds the limit, surfacing as `Http2Exception$HeaderListSizeException: Header size exceeded max allowed size (8192)` on Apache Arrow Flight SQL JDBC clients that forward unrecognized JDBC URL parameters as gRPC headers. SQL itself is unaffected (it's sent in the request body), so the symptom was misleading. Default is `0` (= keep gRPC's default); set to e.g. `65536` if your clients legitimately ship large per-call metadata (extra JDBC URL parameters, large bearer tokens, accumulated cookies, proxy-injected trace headers).
+
+### Fixed
+
+- **`GetTables(include_schema=true)` now emits `ARROW:FLIGHT:SQL:TYPE_NAME` per column.** ADBC Flight SQL clients (e.g. the Apache `libadbc_driver_flightsql` driver used by Power BI's `Adbc.DataSource()` M function) populate `xdbc_type_name` from this Flight SQL standard metadata key. Previously it was unset, so `adbc_get_objects(depth='columns')` returned `xdbc_type_name=None` for every column, breaking type resolution in Power BI's Power Query connector. The value is taken verbatim from DuckDB's `duckdb_columns().data_type`, with parameter / decoration suffixes stripped (`DECIMAL(18,3)` → `DECIMAL`, `INTEGER[]` → `INTEGER`, `STRUCT(...)` → `STRUCT`).
+
 ## [1.22.5] - 2026-05-04
 
 ### Changed

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -440,6 +440,7 @@ GizmoSQL can be configured via environment variables or CLI flags. Below are the
 | access-log / GIZMOSQL_ACCESS_LOG | Per-RPC access logging: on|off | off (if unset) | --access-log |
 | log-file / GIZMOSQL_LOG_FILE | Log file path; '-' => stdout; empty => stderr | stderr (if unset) | --log-file |
 | query-timeout | Query timeout in seconds (0 = unlimited) | DEFAULT_QUERY_TIMEOUT_SECONDS | --query-timeout |
+| max-metadata-size / GIZMOSQL_MAX_METADATA_SIZE | Max inbound gRPC HTTP/2 header metadata bytes per call (`GRPC_ARG_MAX_METADATA_SIZE`). Raise above the gRPC default of ~8 KB if clients send large per-call metadata (e.g. extra Apache Flight SQL JDBC URL parameters that get forwarded as gRPC headers, large bearer tokens, accumulated cookies, proxy-injected trace headers) | 0 (= use gRPC default) | --max-metadata-size |
 | query-log-level / GIZMOSQL_QUERY_LOG_LEVEL | Query log level | info (if unset) | --query-log-level |
 | auth-log-level / GIZMOSQL_AUTH_LOG_LEVEL | Authentication log level | info (if unset) | --auth-log-level |
 | health-port | Plaintext gRPC health check port (0 = disable) | DEFAULT_HEALTH_PORT | --health-port |

--- a/scripts/start_gizmosql.sh
+++ b/scripts/start_gizmosql.sh
@@ -44,6 +44,7 @@
 #   GIZMOSQL_OAUTH_REDIRECT_URI          --oauth-redirect-uri
 #   GIZMOSQL_OAUTH_INSTANCE_ID           --oauth-instance-id
 #   GIZMOSQL_OAUTH_DISABLE_TLS           --oauth-disable-tls (localhost only!)
+#   GIZMOSQL_MAX_METADATA_SIZE           --max-metadata-size
 #
 # ── Escape hatch ────────────────────────────────────────────────────────────
 #   GIZMOSQL_EXTRA_ARGS       Appended verbatim to the command line.

--- a/scripts/start_gizmosql_slim.sh
+++ b/scripts/start_gizmosql_slim.sh
@@ -47,6 +47,7 @@
 #   GIZMOSQL_OAUTH_REDIRECT_URI          --oauth-redirect-uri
 #   GIZMOSQL_OAUTH_INSTANCE_ID           --oauth-instance-id
 #   GIZMOSQL_OAUTH_DISABLE_TLS           --oauth-disable-tls (localhost only!)
+#   GIZMOSQL_MAX_METADATA_SIZE           --max-metadata-size
 #
 # ── Escape hatch ────────────────────────────────────────────────────────────
 #   GIZMOSQL_EXTRA_ARGS       Appended verbatim to the command line.

--- a/src/common/gizmosql_library.cpp
+++ b/src/common/gizmosql_library.cpp
@@ -483,7 +483,8 @@ arrow::Result<std::shared_ptr<flight::sql::FlightSqlServerBase>> FlightSQLServer
     const std::string& oauth_redirect_uri,
     const std::string& oauth_instance_id,
     const bool& oauth_disable_tls,
-    const bool& telemetry_enabled) {
+    const bool& telemetry_enabled,
+    int32_t max_metadata_size) {
   ARROW_ASSIGN_OR_RAISE(auto location,
                         (!tls_cert_path.empty())
                             ? flight::Location::ForGrpcTls(hostname, port)
@@ -889,15 +890,39 @@ arrow::Result<std::shared_ptr<flight::sql::FlightSqlServerBase>> FlightSQLServer
           });
     }
 
-    // Set up builder_hook to register the health service and reflection with the gRPC server
-    if (g_health_service) {
+    // Set up builder_hook to (a) configure GRPC_ARG_MAX_METADATA_SIZE if requested
+    // and (b) register the health service and reflection with the gRPC server.
+    // The hook always runs when there is *something* to do; either condition
+    // alone is sufficient.
+    const bool register_health = static_cast<bool>(g_health_service);
+    const bool tune_metadata = max_metadata_size > 0;
+    if (register_health) {
       // Enable gRPC reflection (must be called before building the server)
       grpc::reflection::InitProtoReflectionServerBuilderPlugin();
-
-      options.builder_hook = [health_service = g_health_service](void* raw_builder) {
+    }
+    if (register_health || tune_metadata) {
+      options.builder_hook = [health_service = g_health_service, max_metadata_size,
+                              register_health](void* raw_builder) {
         auto* builder = reinterpret_cast<grpc::ServerBuilder*>(raw_builder);
-        builder->RegisterService(health_service.get());
+        if (max_metadata_size > 0) {
+          // Maps to GRPC_ARG_MAX_METADATA_SIZE; gRPC's default is ~8 KB and
+          // is too small when clients send large per-call metadata
+          // (e.g. extra JDBC URL params that the Apache Flight SQL JDBC
+          // driver forwards as gRPC headers, large bearer tokens, or
+          // accumulated cookies).
+          builder->AddChannelArgument(GRPC_ARG_MAX_METADATA_SIZE,
+                                      max_metadata_size);
+        }
+        if (register_health && health_service) {
+          builder->RegisterService(health_service.get());
+        }
       };
+    }
+    if (tune_metadata) {
+      GIZMOSQL_LOG(INFO) << "gRPC max metadata size set to: " << max_metadata_size
+                         << " bytes";
+    }
+    if (register_health) {
       GIZMOSQL_LOG(INFO) << "gRPC Health service enabled (on main TLS port)";
       GIZMOSQL_LOG(INFO) << "gRPC Reflection service enabled";
     }
@@ -975,7 +1000,8 @@ arrow::Result<std::shared_ptr<flight::sql::FlightSqlServerBase>> CreateFlightSQL
     std::string oauth_redirect_uri,
     std::string oauth_instance_id,
     const bool& oauth_disable_tls,
-    const bool& telemetry_enabled) {
+    const bool& telemetry_enabled,
+    int32_t max_metadata_size) {
   // Validate and default the arguments to env var values where applicable
   if (database_filename.empty() || database_filename == ":memory:") {
     GIZMOSQL_LOG(INFO)
@@ -1260,7 +1286,8 @@ arrow::Result<std::shared_ptr<flight::sql::FlightSqlServerBase>> CreateFlightSQL
       instrumentation_catalog, instrumentation_schema, instance_tag,
       allow_cross_instance_tokens,
       oauth_client_id, oauth_client_secret, oauth_scopes, oauth_port, oauth_base_url,
-      oauth_redirect_uri, oauth_instance_id, oauth_disable_tls, telemetry_enabled);
+      oauth_redirect_uri, oauth_instance_id, oauth_disable_tls, telemetry_enabled,
+      max_metadata_size);
 }
 
 arrow::Status StartFlightSQLServer(
@@ -1347,7 +1374,8 @@ int RunFlightSQLServer(const BackendType backend, fs::path database_filename,
                        std::optional<bool> oauth_disable_tls,
                        std::optional<bool> otel_enabled, std::string otel_exporter,
                        std::string otel_endpoint, std::string otel_service_name,
-                       std::string otel_headers) {
+                       std::string otel_headers,
+                       int32_t max_metadata_size) {
   // ---- Logging normalization (library-owned) ----------------
   auto pick = [&](std::string v, const char* env_name, std::string def) -> std::string {
     if (!v.empty()) return v;
@@ -1419,6 +1447,28 @@ int RunFlightSQLServer(const BackendType backend, fs::path database_filename,
   resolve_bool_env(oauth_disable_tls, "GIZMOSQL_OAUTH_DISABLE_TLS");
   resolve_bool_env(otel_enabled, "GIZMOSQL_OTEL_ENABLED");
   // ----------------------------------------------------------
+
+  // Integer env var fallback for max_metadata_size: only consult env when the
+  // CLI/library caller left it at the sentinel default (0). Negative values
+  // are rejected. Invalid env values fall back to 0 (= use gRPC default).
+  if (max_metadata_size <= 0) {
+    auto env = gizmosql::SafeGetEnvVarValue("GIZMOSQL_MAX_METADATA_SIZE");
+    if (!env.empty()) {
+      try {
+        int parsed = std::stoi(env);
+        if (parsed > 0) {
+          max_metadata_size = parsed;
+        } else if (parsed < 0) {
+          std::cerr << "GIZMOSQL_MAX_METADATA_SIZE must be a positive integer; got '"
+                    << env << "', ignoring." << std::endl;
+        }
+      } catch (const std::exception&) {
+        std::cerr << "GIZMOSQL_MAX_METADATA_SIZE is not a valid integer ('"
+                  << env << "'), ignoring." << std::endl;
+      }
+    }
+    if (max_metadata_size < 0) max_metadata_size = 0;
+  }
 
   auto now = std::chrono::system_clock::now();
   std::time_t currentTime = std::chrono::system_clock::to_time_t(now);
@@ -1518,7 +1568,8 @@ int RunFlightSQLServer(const BackendType backend, fs::path database_filename,
       instrumentation_catalog, instrumentation_schema, instance_tag,
       allow_cross_instance_tokens.value(),
       oauth_client_id, oauth_client_secret, oauth_scopes, oauth_port, oauth_base_url,
-      oauth_redirect_uri, oauth_instance_id, oauth_disable_tls.value(), telemetry_enabled);
+      oauth_redirect_uri, oauth_instance_id, oauth_disable_tls.value(), telemetry_enabled,
+      max_metadata_size);
 
   if (create_server_result.ok()) {
     auto server_ptr = create_server_result.ValueOrDie();

--- a/src/common/include/gizmosql_library.h
+++ b/src/common/include/gizmosql_library.h
@@ -29,6 +29,7 @@ const int DEFAULT_FLIGHT_PORT = 31337;
 const int DEFAULT_HEALTH_PORT = 31338;  // Plaintext health check port for Kubernetes
 const int DEFAULT_OAUTH_PORT = 31339;  // OAuth HTTP server port
 const int32_t DEFAULT_QUERY_TIMEOUT_SECONDS = 0;  // Unlimited timeout
+const int32_t DEFAULT_MAX_METADATA_SIZE = 0;  // 0 = use gRPC default (~8 KB)
 
 enum class BackendType { duckdb, sqlite };
 
@@ -88,6 +89,7 @@ enum class BackendType { duckdb, sqlite };
  * @param otel_endpoint OTLP endpoint. Default is "" - if so, uses env GIZMOSQL_OTEL_ENDPOINT, fallback based on exporter type.
  * @param otel_service_name Service name for telemetry. Default is "" - if so, uses env GIZMOSQL_OTEL_SERVICE_NAME, fallback to "gizmosql".
  * @param otel_headers Additional headers for OTLP exporter (key1=value1,key2=value2). Default is "" - if so, uses env GIZMOSQL_OTEL_HEADERS.
+ * @param max_metadata_size Maximum size in bytes of inbound gRPC HTTP/2 header metadata per call (sets GRPC_ARG_MAX_METADATA_SIZE). gRPC's default is ~8 KB; raise this if clients legitimately send large per-call metadata (e.g. extra JDBC URL parameters that the Flight SQL JDBC driver forwards as headers, large bearer tokens, accumulated cookies, or proxy-injected trace headers). 0 = use the gRPC default. If 0, uses env var GIZMOSQL_MAX_METADATA_SIZE.
  *
  * @return Returns an integer status code. 0 indicates success, and non-zero values indicate errors.
  */
@@ -156,5 +158,6 @@ int RunFlightSQLServer(
     std::optional<bool> oauth_disable_tls = std::nullopt,
     std::optional<bool> otel_enabled = std::nullopt, std::string otel_exporter = "",
     std::string otel_endpoint = "", std::string otel_service_name = "",
-    std::string otel_headers = "");
+    std::string otel_headers = "",
+    int32_t max_metadata_size = DEFAULT_MAX_METADATA_SIZE);
 }

--- a/src/duckdb/duckdb_tables_schema_batch_reader.cpp
+++ b/src/duckdb/duckdb_tables_schema_batch_reader.cpp
@@ -101,7 +101,7 @@ Status DuckDBTablesWithSchemaBatchReader::ReadNext(
             columns_stmt,
             DuckDBStatement::Create(
                 client_session_,
-                "SELECT column_name, is_nullable, comment, column_default "
+                "SELECT column_name, is_nullable, comment, column_default, data_type "
                 "FROM duckdb_columns() "
                 "WHERE database_name = ? AND schema_name = ? AND table_name = ?",
                 arrow::util::ArrowLogLevel::ARROW_DEBUG, false, nullptr,
@@ -115,6 +115,7 @@ Status DuckDBTablesWithSchemaBatchReader::ReadNext(
           std::string comment;       // Empty = no comment.
           std::string column_default;  // Empty = no default.
           bool has_default = false;
+          std::string type_name;     // DuckDB SQL type name (base form, e.g. "DOUBLE").
         };
         std::unordered_map<std::string, ColumnInfo> info_by_column;
 
@@ -133,6 +134,8 @@ Status DuckDBTablesWithSchemaBatchReader::ReadNext(
                 batch->GetColumnByName("comment"));
             auto default_arr = std::static_pointer_cast<arrow::StringArray>(
                 batch->GetColumnByName("column_default"));
+            auto type_arr = std::static_pointer_cast<arrow::StringArray>(
+                batch->GetColumnByName("data_type"));
             if (!name_arr) break;
             for (int64_t r = 0; r < batch->num_rows(); ++r) {
               if (name_arr->IsNull(r)) continue;
@@ -146,6 +149,18 @@ Status DuckDBTablesWithSchemaBatchReader::ReadNext(
               if (default_arr && !default_arr->IsNull(r)) {
                 info.column_default = std::string(default_arr->GetView(r));
                 info.has_default = true;
+              }
+              if (type_arr && !type_arr->IsNull(r)) {
+                // DuckDB's `data_type` includes parameters / decorations
+                // (e.g. "DECIMAL(18,3)", "INTEGER[]", "STRUCT(a INTEGER)").
+                // Strip to the base type name so consumers (Power BI's ADBC
+                // connector matches on literals like "DECIMAL", "DOUBLE",
+                // "INTEGER", "VARCHAR") see the canonical name.
+                std::string type = std::string(type_arr->GetView(r));
+                size_t end = type.find_first_of("([");
+                if (end == std::string::npos) end = type.find(' ');
+                if (end != std::string::npos) type.resize(end);
+                info.type_name = std::move(type);
               }
               info_by_column.emplace(std::string(name_arr->GetView(r)), std::move(info));
             }
@@ -175,6 +190,11 @@ Status DuckDBTablesWithSchemaBatchReader::ReadNext(
             }
             if (!info.comment.empty()) {
               md["ARROW:FLIGHT:SQL:REMARKS"] = info.comment;
+            }
+            // Standard Flight SQL key — read by ADBC clients (e.g. the Apache
+            // FlightSQL ADBC driver populates xdbc_type_name from this).
+            if (!info.type_name.empty()) {
+              md["ARROW:FLIGHT:SQL:TYPE_NAME"] = info.type_name;
             }
             // DuckDB's auto-increment idiom is a DEFAULT of `nextval('...')`. Mark the
             // column as IS_AUTO_INCREMENT so the JDBC driver can surface it as "YES".
@@ -212,7 +232,8 @@ Status DuckDBTablesWithSchemaBatchReader::ReadNext(
                                           std::move(new_metadata));
             corrected_fields.emplace_back(new_field);
             if (f->nullable() != info.is_nullable || !info.comment.empty() ||
-                info.has_default || md.count("ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT")) {
+                info.has_default || md.count("ARROW:FLIGHT:SQL:IS_AUTO_INCREMENT") ||
+                !info.type_name.empty()) {
               any_changed = true;
             }
           }

--- a/src/gizmosql_server.cpp
+++ b/src/gizmosql_server.cpp
@@ -98,6 +98,13 @@ int main(int argc, char** argv) {
              "Log file path; use '-' for stdout; empty => stderr. Can also use env GIZMOSQL_LOG_FILE.")
             ("query-timeout",   po::value<int32_t>()->default_value(DEFAULT_QUERY_TIMEOUT_SECONDS),
              "The Query Timeout limit in seconds.  A value of 0 means unlimited.")
+            ("max-metadata-size", po::value<int32_t>()->default_value(DEFAULT_MAX_METADATA_SIZE),
+             "Maximum size in bytes of inbound gRPC HTTP/2 header metadata per call "
+             "(GRPC_ARG_MAX_METADATA_SIZE). gRPC's default is ~8 KB; raise this if clients "
+             "legitimately send large per-call metadata (e.g. extra JDBC URL parameters that "
+             "the Apache Flight SQL JDBC driver forwards as gRPC headers, large bearer tokens, "
+             "accumulated cookies, or proxy-injected trace headers). 0 = use the gRPC default. "
+             "If 0, uses env var GIZMOSQL_MAX_METADATA_SIZE.")
             ("query-log-level",  po::value<std::string>()->default_value(""),
              "Query Log level: debug|info|warn|error|fatal. If empty, uses env GIZMOSQL_QUERY_LOG_LEVEL or defaults to info.")
             ("auth-log-level",  po::value<std::string>()->default_value(""),
@@ -300,6 +307,8 @@ int main(int argc, char** argv) {
   int32_t query_timeout =
       vm.count("query-timeout") ? vm["query-timeout"].as<int32_t>() : 0;
 
+  int32_t max_metadata_size = vm["max-metadata-size"].as<int32_t>();
+
   std::string query_log_level =
       vm.count("query-log-level") ? vm["query-log-level"].as<std::string>() : "";
   std::string auth_log_level =
@@ -381,5 +390,5 @@ int main(int argc, char** argv) {
       instrumentation_catalog, instrumentation_schema, instance_tag, license_key_file,
       allow_cross_instance_tokens, oauth_client_id, oauth_client_secret, oauth_scopes,
       oauth_port, oauth_base_url, oauth_redirect_uri, oauth_instance_id, oauth_disable_tls, otel_enabled, otel_exporter,
-      otel_endpoint, otel_service_name, otel_headers);
+      otel_endpoint, otel_service_name, otel_headers, max_metadata_size);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ set(GIZMOSQL_CORE_TEST_SRCS
         integration/test_interactive_client.cpp
         integration/test_internal_query_log_level.cpp
         integration/test_log_level_filtering.cpp
+        integration/test_max_metadata_size.cpp
         integration/test_set_query_log_level.cpp
         integration/test_sqlite_backend.cpp
         integration/test_system_catalog.cpp

--- a/tests/integration/test_max_metadata_size.cpp
+++ b/tests/integration/test_max_metadata_size.cpp
@@ -1,0 +1,317 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+
+// Tests for --max-metadata-size / GIZMOSQL_MAX_METADATA_SIZE.
+//
+// gRPC C++'s default GRPC_ARG_MAX_METADATA_SIZE is ~8 KB. Clients that send
+// large per-call metadata (e.g. extra Apache Flight SQL JDBC URL parameters
+// forwarded as gRPC headers, large bearer tokens, accumulated cookies, or
+// proxy-injected trace headers) hit
+//
+//   Http2Exception$HeaderListSizeException: Header size exceeded max allowed size (8192)
+//
+// These tests verify both the CLI/library `max_metadata_size` argument AND
+// its env var fallback (`GIZMOSQL_MAX_METADATA_SIZE`) actually raise the
+// server's HTTP/2 SETTINGS_MAX_HEADER_LIST_SIZE.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <string>
+#include <thread>
+
+#include "arrow/api.h"
+#include "arrow/flight/sql/client.h"
+#include "arrow/flight/sql/types.h"
+#include "arrow/testing/gtest_util.h"
+#include "test_server_fixture.h"
+#include "test_util.h"
+
+using arrow::flight::sql::FlightSqlClient;
+
+namespace {
+
+// Build a custom ASCII header value of the requested size. We avoid the
+// `authorization` header (the server rewrites that with a Bearer token) and
+// instead use a benign custom key. gRPC counts the *full* header list, so
+// the per-header value just needs to push the list over the limit.
+std::string MakeBigHeaderValue(size_t bytes) {
+  return std::string(bytes, 'A');
+}
+
+// Send a SELECT 1 with `payload` set on a custom header `x-test-payload`.
+// Returns the call status (OK if the server accepted the headers and replied
+// successfully; non-OK if either the local gRPC stack or the server rejected
+// the oversized header list).
+arrow::Status TrySelectWithBigHeader(int port, const std::string& username,
+                                     const std::string& password,
+                                     const std::string& payload) {
+  arrow::flight::FlightClientOptions options;
+  ARROW_ASSIGN_OR_RAISE(auto location,
+                        arrow::flight::Location::ForGrpcTcp("localhost", port));
+  ARROW_ASSIGN_OR_RAISE(auto client,
+                        arrow::flight::FlightClient::Connect(location, options));
+
+  ARROW_ASSIGN_OR_RAISE(auto bearer,
+                        client->AuthenticateBasicToken({}, username, password));
+
+  arrow::flight::FlightCallOptions call_options;
+  call_options.headers.push_back(bearer);
+  call_options.headers.push_back({"x-test-payload", payload});
+
+  FlightSqlClient sql_client(std::move(client));
+  ARROW_ASSIGN_OR_RAISE(auto info,
+                        sql_client.Execute(call_options, "SELECT 1 AS result"));
+  for (const auto& endpoint : info->endpoints()) {
+    ARROW_ASSIGN_OR_RAISE(auto reader,
+                          sql_client.DoGet(call_options, endpoint.ticket));
+    std::shared_ptr<arrow::Table> table;
+    ARROW_ASSIGN_OR_RAISE(table, reader->ToTable());
+    if (table->num_rows() != 1) {
+      return arrow::Status::Invalid("expected one row, got ", table->num_rows());
+    }
+  }
+  return arrow::Status::OK();
+}
+
+}  // namespace
+
+// =============================================================================
+// Fixture A: server with the gRPC default limit (~8 KB).
+// =============================================================================
+
+class MaxMetadataDefaultFixture
+    : public gizmosql::testing::ServerTestFixture<MaxMetadataDefaultFixture> {
+ public:
+  static gizmosql::testing::TestServerConfig GetConfig() {
+    return {
+        .database_filename = "max_metadata_default.db",
+        .port = 31385,
+        .health_port = 31386,
+        .username = "testuser",
+        .password = "testpassword",
+        // max_metadata_size left at default 0 (= use gRPC default ~8 KB)
+    };
+  }
+};
+
+template <>
+std::shared_ptr<arrow::flight::sql::FlightSqlServerBase>
+    gizmosql::testing::ServerTestFixture<MaxMetadataDefaultFixture>::server_{};
+template <>
+std::thread
+    gizmosql::testing::ServerTestFixture<MaxMetadataDefaultFixture>::server_thread_{};
+template <>
+std::atomic<bool>
+    gizmosql::testing::ServerTestFixture<MaxMetadataDefaultFixture>::server_ready_{false};
+template <>
+gizmosql::testing::TestServerConfig
+    gizmosql::testing::ServerTestFixture<MaxMetadataDefaultFixture>::config_{};
+
+TEST_F(MaxMetadataDefaultFixture, SmallHeaderSucceeds) {
+  ASSERT_TRUE(IsServerReady()) << "Server not ready";
+  // ~1 KB header — well under the gRPC default of ~8 KB.
+  auto status = TrySelectWithBigHeader(GetPort(), GetUsername(), GetPassword(),
+                                       MakeBigHeaderValue(1024));
+  ASSERT_TRUE(status.ok()) << "small header should be accepted: "
+                            << status.ToString();
+}
+
+TEST_F(MaxMetadataDefaultFixture, OversizedHeaderRejected) {
+  ASSERT_TRUE(IsServerReady()) << "Server not ready";
+  // 12 KB header value — exceeds the gRPC default of ~8 KB and must be
+  // rejected somewhere in the gRPC HTTP/2 stack (client- or server-side).
+  auto status = TrySelectWithBigHeader(GetPort(), GetUsername(), GetPassword(),
+                                       MakeBigHeaderValue(12 * 1024));
+  ASSERT_FALSE(status.ok())
+      << "oversized header should be rejected at the gRPC default limit";
+}
+
+// =============================================================================
+// Fixture B: server with explicit max_metadata_size = 64 KB (CLI/library arg).
+// =============================================================================
+
+class MaxMetadataRaisedFixture
+    : public gizmosql::testing::ServerTestFixture<MaxMetadataRaisedFixture> {
+ public:
+  static gizmosql::testing::TestServerConfig GetConfig() {
+    return {
+        .database_filename = "max_metadata_raised.db",
+        .port = 31387,
+        .health_port = 31388,
+        .username = "testuser",
+        .password = "testpassword",
+        .max_metadata_size = 64 * 1024,
+    };
+  }
+};
+
+template <>
+std::shared_ptr<arrow::flight::sql::FlightSqlServerBase>
+    gizmosql::testing::ServerTestFixture<MaxMetadataRaisedFixture>::server_{};
+template <>
+std::thread
+    gizmosql::testing::ServerTestFixture<MaxMetadataRaisedFixture>::server_thread_{};
+template <>
+std::atomic<bool>
+    gizmosql::testing::ServerTestFixture<MaxMetadataRaisedFixture>::server_ready_{false};
+template <>
+gizmosql::testing::TestServerConfig
+    gizmosql::testing::ServerTestFixture<MaxMetadataRaisedFixture>::config_{};
+
+TEST_F(MaxMetadataRaisedFixture, OversizedHeaderAcceptedWhenLimitRaised) {
+  ASSERT_TRUE(IsServerReady()) << "Server not ready";
+  // 12 KB header — would be rejected at the default ~8 KB limit, but must
+  // succeed when the server is configured with max_metadata_size = 64 KB.
+  auto status = TrySelectWithBigHeader(GetPort(), GetUsername(), GetPassword(),
+                                       MakeBigHeaderValue(12 * 1024));
+  ASSERT_TRUE(status.ok())
+      << "12 KB header should be accepted with max_metadata_size = 64 KB: "
+      << status.ToString();
+}
+
+// =============================================================================
+// Env var path: spin up a server in-process via RunFlightSQLServer with the
+// arg left at 0 and GIZMOSQL_MAX_METADATA_SIZE set in the environment, then
+// verify the same oversized header is accepted. This exercises the library
+// env var fallback (the same code path container deployments rely on).
+// =============================================================================
+
+#ifndef _WIN32
+namespace {
+
+class EnvVarGuard {
+ public:
+  EnvVarGuard(const char* name, const char* value) : name_(name) {
+    const char* prev = std::getenv(name);
+    had_prev_ = prev != nullptr;
+    if (had_prev_) prev_ = prev;
+    setenv(name, value, /*overwrite=*/1);
+  }
+  ~EnvVarGuard() {
+    if (had_prev_) {
+      setenv(name_.c_str(), prev_.c_str(), /*overwrite=*/1);
+    } else {
+      unsetenv(name_.c_str());
+    }
+  }
+  EnvVarGuard(const EnvVarGuard&) = delete;
+  EnvVarGuard& operator=(const EnvVarGuard&) = delete;
+
+ private:
+  std::string name_;
+  bool had_prev_;
+  std::string prev_;
+};
+
+}  // namespace
+
+TEST(MaxMetadataEnvVar, EnvVarRaisesLimit) {
+  // Set the env var BEFORE creating the server so RunFlightSQLServer's
+  // resolver picks it up.
+  EnvVarGuard env_guard("GIZMOSQL_MAX_METADATA_SIZE", "65536");
+
+  const int kPort = 31389;
+  const int kHealthPort = 31390;
+  const std::string kUser = "testuser";
+  const std::string kPass = "testpassword";
+  const std::string kDb = "max_metadata_envvar.db";
+  std::error_code ec;
+  std::filesystem::remove(kDb, ec);
+
+  // Run RunFlightSQLServer on a background thread. We pass max_metadata_size = 0
+  // so the env var fallback is the only thing that can raise the limit.
+  std::thread server_thread([&]() {
+    RunFlightSQLServer(
+        BackendType::duckdb, std::filesystem::path(kDb),
+        /*hostname=*/"localhost", kPort, kUser, kPass,
+        /*secret_key=*/"test_secret_key_for_testing",
+        /*tls_cert_path=*/std::filesystem::path(),
+        /*tls_key_path=*/std::filesystem::path(),
+        /*mtls_ca_cert_path=*/std::filesystem::path(),
+        /*init_sql_commands=*/"",
+        /*init_sql_commands_file=*/std::filesystem::path(),
+        /*print_queries=*/false,
+        /*read_only=*/false,
+        /*token_allowed_issuer=*/"",
+        /*token_allowed_audience=*/"",
+        /*token_signature_verify_cert_path=*/std::filesystem::path(),
+        /*token_jwks_uri=*/"",
+        /*token_default_role=*/"",
+        /*token_authorized_emails=*/"",
+        /*log_level=*/"warn",
+        /*log_format=*/"text",
+        /*access_log=*/"off",
+        /*log_file=*/"",
+        /*query_timeout=*/0,
+        /*query_log_level=*/"warn",
+        /*auth_log_level=*/"warn",
+        /*health_port=*/kHealthPort,
+        /*health_check_query=*/"",
+        /*enable_instrumentation=*/std::optional<bool>(false),
+        /*instrumentation_db_path=*/"",
+        /*instrumentation_catalog=*/"",
+        /*instrumentation_schema=*/"",
+        /*instance_tag=*/"",
+        /*license_key_file=*/"",
+        /*allow_cross_instance_tokens=*/std::optional<bool>(false),
+        /*oauth_client_id=*/"",
+        /*oauth_client_secret=*/"",
+        /*oauth_scopes=*/"",
+        /*oauth_port=*/0,
+        /*oauth_base_url=*/"",
+        /*oauth_redirect_uri=*/"",
+        /*oauth_instance_id=*/"",
+        /*oauth_disable_tls=*/std::optional<bool>(false),
+        /*otel_enabled=*/std::optional<bool>(false),
+        /*otel_exporter=*/"",
+        /*otel_endpoint=*/"",
+        /*otel_service_name=*/"",
+        /*otel_headers=*/"",
+        /*max_metadata_size=*/0);
+  });
+
+  // Wait for the server to come up. The fixture pattern uses a 100ms grace
+  // after the `Serve()` call returns ready; we don't have that signal here,
+  // so probe via repeated connect attempts up to a timeout.
+  bool reachable = false;
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(15);
+  while (std::chrono::steady_clock::now() < deadline) {
+    arrow::flight::FlightClientOptions opts;
+    auto loc = arrow::flight::Location::ForGrpcTcp("localhost", kPort);
+    if (loc.ok()) {
+      auto cl = arrow::flight::FlightClient::Connect(*loc, opts);
+      if (cl.ok()) {
+        auto auth = (*cl)->AuthenticateBasicToken({}, kUser, kPass);
+        if (auth.ok()) {
+          reachable = true;
+          break;
+        }
+      }
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  }
+  ASSERT_TRUE(reachable) << "env-var server failed to come up";
+
+  auto status = TrySelectWithBigHeader(kPort, kUser, kPass,
+                                       MakeBigHeaderValue(12 * 1024));
+  EXPECT_TRUE(status.ok())
+      << "GIZMOSQL_MAX_METADATA_SIZE=65536 should permit 12 KB headers: "
+      << status.ToString();
+
+  // Tear down.
+  ShutdownFlightServer();
+  if (server_thread.joinable()) server_thread.join();
+  gizmosql::CleanupServerResources();
+  std::filesystem::remove(kDb, ec);
+  std::filesystem::remove(kDb + ".wal", ec);
+}
+#endif  // !_WIN32

--- a/tests/integration/test_server_fixture.h
+++ b/tests/integration/test_server_fixture.h
@@ -69,7 +69,8 @@ CreateFlightSQLServer(
     std::string oauth_redirect_uri = "",
     std::string oauth_instance_id = "",
     const bool& oauth_disable_tls = false,
-    const bool& telemetry_enabled = false);
+    const bool& telemetry_enabled = false,
+    int32_t max_metadata_size = 0);
 
 // Cleanup function to reset global state between test suites
 void CleanupServerResources();
@@ -109,6 +110,7 @@ struct TestServerConfig {
   bool print_queries = false;                    // Enable query logging
   arrow::util::ArrowLogLevel query_log_level =
       arrow::util::ArrowLogLevel::ARROW_INFO;    // Query log level threshold
+  int32_t max_metadata_size = 0;                 // gRPC max header metadata bytes per call (0 = gRPC default ~8 KB)
 };
 
 /// CRTP-based test fixture template for integration tests.
@@ -206,7 +208,9 @@ class ServerTestFixture : public ::testing::Test {
         /*oauth_base_url=*/config_.oauth_base_url,
         /*oauth_redirect_uri=*/config_.oauth_redirect_uri,
         /*oauth_instance_id=*/config_.oauth_instance_id,
-        /*oauth_disable_tls=*/config_.oauth_disable_tls);
+        /*oauth_disable_tls=*/config_.oauth_disable_tls,
+        /*telemetry_enabled=*/false,
+        /*max_metadata_size=*/config_.max_metadata_size);
 
     ASSERT_TRUE(result.ok()) << "Failed to create server: " << result.status().ToString();
     server_ = *result;


### PR DESCRIPTION
## Summary

Two Flight SQL metadata fixes targeting real-world client interop:

- **`GetTables(include_schema=true)` now emits `ARROW:FLIGHT:SQL:TYPE_NAME` per column.** ADBC clients (Apache `libadbc_driver_flightsql`, used by Power BI's `Adbc.DataSource()` M function) populate `xdbc_type_name` from this Flight SQL standard key. Previously it was unset, so `adbc_get_objects(depth='columns')` returned `xdbc_type_name=None` for every column, breaking type resolution in connectors that match on canonical type names. Value comes verbatim from DuckDB's `duckdb_columns().data_type`, with parameter / decoration suffixes stripped (`DECIMAL(18,3)` → `DECIMAL`, `INTEGER[]` → `INTEGER`, `STRUCT(...)` → `STRUCT`).
- **New `--max-metadata-size` / `GIZMOSQL_MAX_METADATA_SIZE`** exposing gRPC's `GRPC_ARG_MAX_METADATA_SIZE`. gRPC's default of ~8 KB rejects calls whose total HTTP/2 header list exceeds the limit, surfacing as `Http2Exception$HeaderListSizeException: Header size exceeded max allowed size (8192)` on Apache Arrow Flight SQL JDBC clients that forward unrecognized JDBC URL parameters as gRPC headers. SQL itself is in the body and unaffected — the symptom was misleading. Default `0` keeps gRPC's default; set e.g. `65536` if clients legitimately ship large per-call metadata (extra JDBC URL parameters, large bearer tokens, accumulated cookies, proxy-injected trace headers).

Env var fallback lives in the library per CLAUDE.md, so direct C-API users get the same behavior as the CLI. Constitutes a minor version bump → **v1.23.0** (new public API parameter + new metadata behavior).

## Verification

- `--max-metadata-size` reproduction confirmed against both Apache Flight SQL JDBC 15.0.0 and our 19.0.0 fork: 12 KB header value rejected at default 8 KB, accepted with `--max-metadata-size=65536`.
- `xdbc_type_name` confirmed via `adbc_get_objects(depth='columns')` against a DuckDB table covering `INTEGER`, `VARCHAR`, `DOUBLE`, `BIGINT`, `SMALLINT`, `DATE`, `TIMESTAMP`, `DECIMAL(18,3)`, `BOOLEAN`, `REAL` — all canonical names returned.
- New `tests/integration/test_max_metadata_size.cpp` covers small-header / oversized-header / raised-limit / **env-var fallback** — all 4 tests pass locally.
- Existing `AuthenticationServerFixture` (30 tests) still passes — no regressions to the Flight SQL plumbing.

## Test plan

- [ ] CI green on Linux, macOS, Windows
- [ ] `tests/gizmosql_integration_tests --gtest_filter='*MaxMetadata*'` → 4 passed
- [ ] `tests/gizmosql_integration_tests --gtest_filter='AuthenticationServerFixture.*'` → 30 passed
- [ ] Manual: bring up server with `--max-metadata-size=65536`, hit it from a JDBC URL with a >8 KB extra parameter, confirm acceptance
- [ ] Manual: `adbc_get_objects(depth='columns')` populates `xdbc_type_name` for every column

## Caller's known limitation

`xdbc_data_type` for `DOUBLE` is computed by the Apache FlightSQL ADBC driver (Go) purely from the Arrow type, with no metadata override path — `Float64` is hardcoded to `XDBC_FLOAT (6)` rather than `XDBC_DOUBLE (8)`. Fixing that needs an upstream PR to arrow-adbc; the workaround on the connector side is to match on `xdbc_type_name` strings (now populated correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
