### PR TITLE
fix: GIZMOSQL_VERSION() and client --version reflect LTS suffix

### DIFF
--- a/docs/lts_channel.md
+++ b/docs/lts_channel.md
@@ -19,18 +19,35 @@ When DuckDB names a new LTS, GizmoSQL bumps `DUCKDB_LTS_VERSION` in `CMakeLists.
 
 ## Telling the channels apart
 
-The LTS server identifies itself in three ways so it's never ambiguous which build is running:
+The LTS server identifies itself in four ways so it's never ambiguous which build is running:
+
+**1. The `--version` flag on both the server and the client binaries**
 
 ```text
 $ gizmosql_server_lts --version
-GizmoSQL Server CLI: v1.24.0-LTS
+GizmoSQL Server CLI: v1.25.0-LTS
+
+$ gizmosql_client_lts --version
+GizmoSQL Client v1.25.0-LTS
 ```
+
+**2. The startup banner**
 
 ```text
-INFO ... GizmoSQL server version: v1.24.0-LTS - with engine: DuckDB (LTS channel — DuckDB v1.4.4) - will listen on grpc+tcp://0.0.0.0:31337
+INFO ... GizmoSQL server version: v1.25.0-LTS - with engine: DuckDB (LTS channel — DuckDB v1.4.4) - will listen on grpc+tcp://0.0.0.0:31337
 ```
 
-The `-LTS` suffix on the version string is also reflected in OpenTelemetry `service.version`, instrumentation records, and any other place the server reports its version.
+**3. The `GIZMOSQL_VERSION()` SQL function** — query it from any client (JDBC, ADBC, gizmosql_client, etc.) to confirm which channel the server you connected to was built from:
+
+```sql
+SELECT GIZMOSQL_VERSION();
+-- v1.25.0-LTS    (when connected to an LTS server)
+-- v1.25.0        (when connected to a stable server)
+```
+
+**4. The `.about` / `.info` dot-commands and the interactive shell banner** in `gizmosql_client_lts` all carry the suffix.
+
+The `-LTS` suffix is also reflected in OpenTelemetry `service.version`, the `gizmosql_version` column on session-instrumentation records, and any other place the server reports its version — so a single string lets you tell at a glance which channel produced any log line, span, or audit row.
 
 ## Artifact naming
 

--- a/src/client/command_processor.cpp
+++ b/src/client/command_processor.cpp
@@ -43,6 +43,7 @@
 #include "output_renderer.hpp"
 #include "password_prompt.hpp"
 #include "version.h"
+#include "gizmosql_library.h"  // GIZMOSQL_SERVER_VERSION (channel-aware)
 
 namespace gizmosql::client {
 
@@ -910,7 +911,7 @@ CommandResult CommandProcessor::Process(const std::string& line) {
   // .about
   if (cmd == ".about") {
     auto& out = *config_.output_stream;
-    out << "GizmoSQL Client " << PROJECT_VERSION << "\n"
+    out << "GizmoSQL Client " << GIZMOSQL_SERVER_VERSION << "\n"
         << "\n"
         << "Copyright (c) 2024-2026 GizmoData LLC\n"
         << "https://gizmodata.com\n"
@@ -1001,7 +1002,7 @@ void CommandProcessor::ShowSettings() {
 
   // --- Client ---
   out << "--- Client ---\n";
-  out << "     version: " << PROJECT_VERSION << "\n";
+  out << "     version: " << GIZMOSQL_SERVER_VERSION << "\n";
 
   // --- Server ---
   if (conn_.IsConnected()) {

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -40,6 +40,7 @@
 #include "shell_loop.hpp"
 #include "sql_processor.hpp"
 #include "version.h"
+#include "gizmosql_library.h"  // GIZMOSQL_SERVER_VERSION (channel-aware)
 
 namespace po = boost::program_options;
 using namespace gizmosql::client;
@@ -165,7 +166,7 @@ int main(int argc, char** argv) {
   }
 
   if (vm.count("version")) {
-    std::cout << "GizmoSQL Client " << PROJECT_VERSION << std::endl;
+    std::cout << "GizmoSQL Client " << GIZMOSQL_SERVER_VERSION << std::endl;
     return 0;
   }
 

--- a/src/client/shell_loop.cpp
+++ b/src/client/shell_loop.cpp
@@ -31,6 +31,7 @@
 #include "shell_completer.hpp"
 #include "syntax_highlighter.hpp"
 #include "version.h"
+#include "gizmosql_library.h"  // GIZMOSQL_SERVER_VERSION (channel-aware)
 
 namespace gizmosql::client {
 
@@ -462,7 +463,7 @@ int RunShellLoop(FlightConnection& conn, CommandProcessor& cmd_proc,
   RefreshDynamicPrompt(conn, config);
 
   if (!config.quiet) {
-    std::cout << "GizmoSQL Client " << PROJECT_VERSION << std::endl;
+    std::cout << "GizmoSQL Client " << GIZMOSQL_SERVER_VERSION << std::endl;
     if (conn.IsConnected()) {
       std::cout << "Connected to " << config.host << ":" << config.port
                 << std::endl;

--- a/src/duckdb/duckdb_statement.cpp
+++ b/src/duckdb/duckdb_statement.cpp
@@ -56,6 +56,7 @@
 #endif
 #include <nlohmann/json.hpp>
 #include "version.h"
+#include "gizmosql_library.h"  // GIZMOSQL_SERVER_VERSION (channel-aware)
 
 using arrow::Status;
 using duckdb::QueryResult;
@@ -425,7 +426,10 @@ std::string ReplaceGizmoSQLFunctions(const std::string& sql,
       std::string upper_candidate = boost::to_upper_copy(candidate);
       if (upper_candidate == "GIZMOSQL_VERSION()") {
         result += '\'';
-        result += PROJECT_VERSION;
+        // Use the channel-aware version string so SELECT GIZMOSQL_VERSION()
+        // on an LTS server returns e.g. "v1.25.0-LTS" rather than the bare
+        // git tag "v1.25.0". Stable builds remain unchanged.
+        result += GIZMOSQL_SERVER_VERSION;
         result += '\'';
         if (ShouldAddAlias(sql, i, i + kVersionFuncLen)) {
           result += " AS \"GIZMOSQL_VERSION()\"";


### PR DESCRIPTION
## Summary

Follow-up to the v1.25.0 LTS channel work: four sites that report the GizmoSQL version still used the raw `PROJECT_VERSION` macro (the bare git tag, e.g. `v1.25.0`) instead of `GIZMOSQL_SERVER_VERSION` (the channel-aware string that adds `-LTS` on LTS builds). On an LTS server the startup banner and the `-DGIZMOSQL_DUCKDB_CHANNEL_LTS=1` build define both said LTS, but these surfaces silently dropped the suffix.

### Sites fixed

| File | Surface |
|---|---|
| `src/duckdb/duckdb_statement.cpp` | The SQL scalar `GIZMOSQL_VERSION()` |
| `src/client/main.cpp` | `gizmosql_client --version` |
| `src/client/shell_loop.cpp` | Banner printed when entering the interactive shell |
| `src/client/command_processor.cpp` | The `.about` and `.info` dot-commands |

All four now use `GIZMOSQL_SERVER_VERSION` from `gizmosql_library.h`, which already had the `#if GIZMOSQL_DUCKDB_CHANNEL_LTS` suffix logic.

## Test plan

- [x] Stable build: server + client `--version` → `v1.25.0` (unchanged)
- [x] LTS build: server + client `--version` → `v1.25.0-LTS`
- [x] `SELECT GIZMOSQL_VERSION();` against the LTS server returns `v1.25.0-LTS`
- [ ] CI green across all matrix combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
