### PR TITLE
feat: add --storage-version / GIZMOSQL_STORAGE_VERSION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`--storage-version` / `GIZMOSQL_STORAGE_VERSION`.** New server option that pins the DuckDB storage format version (e.g. `latest`, `v1.4.0`, `v1.2.0`) for newly created database files, mirroring `duckdb -storage_version <ver>`. Maps directly onto DuckDB's `serialization_compatibility` `DBConfig` option (`SerializationCompatibility::FromString`). Useful for forcing a newer on-disk format so newer DuckDB clients can attach at their newest level, or capping at an older version for cross-version compatibility. Available via the CLI flag, the env var (handy for container deployments), and the `RunFlightSQLServer()` library API. Ignored for the SQLite backend. Default: empty (DuckDB's built-in default applies).
+
 ## [1.25.2] - 2026-05-08
 
 ### Fixed

--- a/scripts/start_gizmosql.sh
+++ b/scripts/start_gizmosql.sh
@@ -46,6 +46,7 @@
 #   GIZMOSQL_OAUTH_INSTANCE_ID           --oauth-instance-id
 #   GIZMOSQL_OAUTH_DISABLE_TLS           --oauth-disable-tls (localhost only!)
 #   GIZMOSQL_MAX_METADATA_SIZE           --max-metadata-size
+#   GIZMOSQL_STORAGE_VERSION             --storage-version (DuckDB only)
 #
 # ── Escape hatch ────────────────────────────────────────────────────────────
 #   GIZMOSQL_EXTRA_ARGS       Appended verbatim to the command line.

--- a/scripts/start_gizmosql_slim.sh
+++ b/scripts/start_gizmosql_slim.sh
@@ -49,6 +49,7 @@
 #   GIZMOSQL_OAUTH_INSTANCE_ID           --oauth-instance-id
 #   GIZMOSQL_OAUTH_DISABLE_TLS           --oauth-disable-tls (localhost only!)
 #   GIZMOSQL_MAX_METADATA_SIZE           --max-metadata-size
+#   GIZMOSQL_STORAGE_VERSION             --storage-version (DuckDB only)
 #
 # ── Escape hatch ────────────────────────────────────────────────────────────
 #   GIZMOSQL_EXTRA_ARGS       Appended verbatim to the command line.

--- a/src/common/gizmosql_library.cpp
+++ b/src/common/gizmosql_library.cpp
@@ -485,7 +485,8 @@ arrow::Result<std::shared_ptr<flight::sql::FlightSqlServerBase>> FlightSQLServer
     const std::string& oauth_instance_id,
     const bool& oauth_disable_tls,
     const bool& telemetry_enabled,
-    int32_t max_metadata_size) {
+    int32_t max_metadata_size,
+    const std::string& storage_version) {
   ARROW_ASSIGN_OR_RAISE(auto location,
                         (!tls_cert_path.empty())
                             ? flight::Location::ForGrpcTls(hostname, port)
@@ -695,6 +696,7 @@ arrow::Result<std::shared_ptr<flight::sql::FlightSqlServerBase>> FlightSQLServer
     ARROW_ASSIGN_OR_RAISE(duckdb_server, gizmosql::ddb::DuckDBFlightSqlServer::Create(
                                              database_filename.string(), read_only, print_queries,
                                              query_timeout, query_log_level, session_log_level,
+                                             storage_version,
                                              nullptr))  // No instrumentation manager yet
 
     // Set instance_id for all future log entries (enables log correlation)
@@ -1017,7 +1019,8 @@ arrow::Result<std::shared_ptr<flight::sql::FlightSqlServerBase>> CreateFlightSQL
     std::string oauth_instance_id,
     const bool& oauth_disable_tls,
     const bool& telemetry_enabled,
-    int32_t max_metadata_size) {
+    int32_t max_metadata_size,
+    std::string storage_version) {
   // Validate and default the arguments to env var values where applicable
   if (database_filename.empty() || database_filename == ":memory:") {
     GIZMOSQL_LOG(INFO)
@@ -1305,7 +1308,7 @@ arrow::Result<std::shared_ptr<flight::sql::FlightSqlServerBase>> CreateFlightSQL
       allow_cross_instance_tokens,
       oauth_client_id, oauth_client_secret, oauth_scopes, oauth_port, oauth_base_url,
       oauth_redirect_uri, oauth_instance_id, oauth_disable_tls, telemetry_enabled,
-      max_metadata_size);
+      max_metadata_size, storage_version);
 }
 
 arrow::Status StartFlightSQLServer(
@@ -1394,7 +1397,8 @@ int RunFlightSQLServer(const BackendType backend, fs::path database_filename,
                        std::optional<bool> otel_enabled, std::string otel_exporter,
                        std::string otel_endpoint, std::string otel_service_name,
                        std::string otel_headers,
-                       int32_t max_metadata_size) {
+                       int32_t max_metadata_size,
+                       std::string storage_version) {
   // ---- Logging normalization (library-owned) ----------------
   auto pick = [&](std::string v, const char* env_name, std::string def) -> std::string {
     if (!v.empty()) return v;
@@ -1411,6 +1415,8 @@ int RunFlightSQLServer(const BackendType backend, fs::path database_filename,
   std::string auth_lvl_s = pick(auth_log_level, "GIZMOSQL_AUTH_LOG_LEVEL", "info");
   std::string session_lvl_s =
       pick(session_log_level, "GIZMOSQL_SESSION_LOG_LEVEL", "info");
+  // DuckDB storage version: empty string => let DuckDB use its built-in default.
+  storage_version = pick(storage_version, "GIZMOSQL_STORAGE_VERSION", "");
 
   auto level = gizmosql::log_level_string_to_arrow_log_level(lvl_s);
   auto query_level = gizmosql::log_level_string_to_arrow_log_level(query_lvl_s);
@@ -1591,7 +1597,7 @@ int RunFlightSQLServer(const BackendType backend, fs::path database_filename,
       allow_cross_instance_tokens.value(),
       oauth_client_id, oauth_client_secret, oauth_scopes, oauth_port, oauth_base_url,
       oauth_redirect_uri, oauth_instance_id, oauth_disable_tls.value(), telemetry_enabled,
-      max_metadata_size);
+      max_metadata_size, storage_version);
 
   if (create_server_result.ok()) {
     auto server_ptr = create_server_result.ValueOrDie();

--- a/src/common/include/gizmosql_library.h
+++ b/src/common/include/gizmosql_library.h
@@ -100,6 +100,7 @@ enum class BackendType { duckdb, sqlite };
  * @param otel_service_name Service name for telemetry. Default is "" - if so, uses env GIZMOSQL_OTEL_SERVICE_NAME, fallback to "gizmosql".
  * @param otel_headers Additional headers for OTLP exporter (key1=value1,key2=value2). Default is "" - if so, uses env GIZMOSQL_OTEL_HEADERS.
  * @param max_metadata_size Maximum size in bytes of inbound gRPC HTTP/2 header metadata per call (sets GRPC_ARG_MAX_METADATA_SIZE). gRPC's default is ~8 KB; raise this if clients legitimately send large per-call metadata (e.g. extra JDBC URL parameters that the Flight SQL JDBC driver forwards as headers, large bearer tokens, accumulated cookies, or proxy-injected trace headers). 0 = use the gRPC default. If 0, uses env var GIZMOSQL_MAX_METADATA_SIZE.
+ * @param storage_version DuckDB storage format version to use when creating new database files (e.g. "latest", "v1.4.0", "v1.2.0"). Maps directly to DuckDB's `storage_version` config option (the same one set by `duckdb -storage_version <ver>`). Useful when you want a database file that newer DuckDB clients can read at their newest format, or to cap the format at an older version for cross-version compatibility. Default is "" - if so, uses env var GIZMOSQL_STORAGE_VERSION; if that is unset, DuckDB's built-in default applies. Ignored for the SQLite backend.
  *
  * @return Returns an integer status code. 0 indicates success, and non-zero values indicate errors.
  */
@@ -170,5 +171,6 @@ int RunFlightSQLServer(
     std::optional<bool> otel_enabled = std::nullopt, std::string otel_exporter = "",
     std::string otel_endpoint = "", std::string otel_service_name = "",
     std::string otel_headers = "",
-    int32_t max_metadata_size = DEFAULT_MAX_METADATA_SIZE);
+    int32_t max_metadata_size = DEFAULT_MAX_METADATA_SIZE,
+    std::string storage_version = "");
 }

--- a/src/duckdb/duckdb_server.cpp
+++ b/src/duckdb/duckdb_server.cpp
@@ -2067,6 +2067,7 @@ Result<std::shared_ptr<DuckDBFlightSqlServer>> DuckDBFlightSqlServer::Create(
     const std::string& path, const bool& read_only, const bool& print_queries,
     const int32_t& query_timeout, const arrow::util::ArrowLogLevel& query_log_level,
     const arrow::util::ArrowLogLevel& session_log_level,
+    const std::string& storage_version,
 #ifdef GIZMOSQL_ENTERPRISE
     std::shared_ptr<InstrumentationManager> instrumentation_manager) {
 #else
@@ -2088,6 +2089,16 @@ Result<std::shared_ptr<DuckDBFlightSqlServer>> DuckDBFlightSqlServer::Create(
     config.options.access_mode = duckdb::AccessMode::READ_ONLY;
   }
 
+  if (!storage_version.empty()) {
+    try {
+      config.options.serialization_compatibility =
+          duckdb::SerializationCompatibility::FromString(storage_version);
+      GIZMOSQL_LOG(INFO) << "DuckDB storage version set to: " << storage_version;
+    } catch (const std::exception& e) {
+      return arrow::Status::Invalid(
+          "Invalid DuckDB storage version '" + storage_version + "': " + e.what());
+    }
+  }
 
   auto db = std::make_shared<duckdb::DuckDB>(db_location, &config);
 

--- a/src/duckdb/duckdb_server.h
+++ b/src/duckdb/duckdb_server.h
@@ -54,6 +54,7 @@ class DuckDBFlightSqlServer : public flight::sql::FlightSqlServerBase,
       const std::string& path, const bool& read_only, const bool& print_queries,
       const int32_t& query_timeout, const arrow::util::ArrowLogLevel& query_log_level,
       const arrow::util::ArrowLogLevel& session_log_level,
+      const std::string& storage_version,
 #ifdef GIZMOSQL_ENTERPRISE
       std::shared_ptr<InstrumentationManager> instrumentation_manager = nullptr);
 #else

--- a/src/gizmosql_server.cpp
+++ b/src/gizmosql_server.cpp
@@ -65,6 +65,11 @@ int main(int argc, char** argv) {
              "Specify an optional mTLS CA certificate path used to verify clients.  The certificate MUST be in PEM format.")
             ("print-queries,Q", po::bool_switch()->default_value(false), "Print queries run by clients to stdout")
             ("readonly,O", po::bool_switch()->default_value(false), "Open the database in read-only mode")
+            ("storage-version", po::value<std::string>()->default_value(""),
+             "[DuckDB only] Storage format version for newly created databases (e.g. 'latest', 'v1.4.0', 'v1.2.0'). "
+             "Maps to DuckDB's `storage_version` config (the same option set by `duckdb -storage_version <ver>`). "
+             "If not set, uses env var GIZMOSQL_STORAGE_VERSION; if that is unset, DuckDB's built-in default applies. "
+             "Ignored when --backend=sqlite.")
             ("token-allowed-issuer", po::value<std::string>()->default_value(""),
              "Specify the allowed token issuer for JWT token-based authentication - see docs for details.  "
              "If not set, we will use env var: 'TOKEN_ALLOWED_ISSUER'.")
@@ -275,6 +280,9 @@ int main(int argc, char** argv) {
 
   bool read_only = vm["readonly"].as<bool>();
 
+  std::string storage_version =
+      vm.count("storage-version") ? vm["storage-version"].as<std::string>() : "";
+
   std::string token_allowed_issuer = "";
   if (vm.count("token-allowed-issuer")) {
     token_allowed_issuer = vm["token-allowed-issuer"].as<std::string>();
@@ -396,5 +404,6 @@ int main(int argc, char** argv) {
       instrumentation_catalog, instrumentation_schema, instance_tag, license_key_file,
       allow_cross_instance_tokens, oauth_client_id, oauth_client_secret, oauth_scopes,
       oauth_port, oauth_base_url, oauth_redirect_uri, oauth_instance_id, oauth_disable_tls, otel_enabled, otel_exporter,
-      otel_endpoint, otel_service_name, otel_headers, max_metadata_size);
+      otel_endpoint, otel_service_name, otel_headers, max_metadata_size,
+      storage_version);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ set(GIZMOSQL_CORE_TEST_SRCS
         integration/test_sqlite_backend.cpp
         integration/test_system_catalog.cpp
         integration/test_read_only_mode.cpp
+        integration/test_storage_version.cpp
         integration/test_token_authorized_emails.cpp
         integration/test_tpch_benchmark.cpp
         integration/test_ducklake.cpp

--- a/tests/integration/test_server_fixture.h
+++ b/tests/integration/test_server_fixture.h
@@ -71,7 +71,8 @@ CreateFlightSQLServer(
     std::string oauth_instance_id = "",
     const bool& oauth_disable_tls = false,
     const bool& telemetry_enabled = false,
-    int32_t max_metadata_size = 0);
+    int32_t max_metadata_size = 0,
+    std::string storage_version = "");
 
 // Cleanup function to reset global state between test suites
 void CleanupServerResources();
@@ -115,6 +116,7 @@ struct TestServerConfig {
   arrow::util::ArrowLogLevel session_log_level =
       arrow::util::ArrowLogLevel::ARROW_INFO;    // Session lifecycle log level threshold
   int32_t max_metadata_size = 0;                 // gRPC max header metadata bytes per call (0 = gRPC default ~8 KB)
+  std::string storage_version = "";              // [DuckDB] storage_version (e.g. "latest"); empty => DuckDB default
 };
 
 /// CRTP-based test fixture template for integration tests.
@@ -215,7 +217,8 @@ class ServerTestFixture : public ::testing::Test {
         /*oauth_instance_id=*/config_.oauth_instance_id,
         /*oauth_disable_tls=*/config_.oauth_disable_tls,
         /*telemetry_enabled=*/false,
-        /*max_metadata_size=*/config_.max_metadata_size);
+        /*max_metadata_size=*/config_.max_metadata_size,
+        /*storage_version=*/config_.storage_version);
 
     ASSERT_TRUE(result.ok()) << "Failed to create server: " << result.status().ToString();
     server_ = *result;

--- a/tests/integration/test_storage_version.cpp
+++ b/tests/integration/test_storage_version.cpp
@@ -1,0 +1,184 @@
+// Verifies that the DuckDB `storage_version` config option (exposed via the
+// --storage-version CLI flag / GIZMOSQL_STORAGE_VERSION env var / library
+// `storage_version` parameter) is actually applied to the underlying DuckDB
+// instance.
+//
+// Uses `FROM duckdb_databases()` and checks the `tags` map: when
+// storage_version is set to "latest" against a fresh database file, DuckDB
+// stamps the on-disk tag with the newest format the running engine supports
+// (e.g. "v1.5.0+"), instead of the default "v1.0.0+" tag that a
+// brand-new DB would otherwise carry.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include "arrow/api.h"
+#include "arrow/flight/sql/client.h"
+#include "arrow/testing/gtest_util.h"
+#include "test_server_fixture.h"
+#include "test_util.h"
+
+using arrow::flight::sql::FlightSqlClient;
+
+namespace {
+
+// Pull `tags['storage_version']` for the user database row out of
+// duckdb_databases(). On DuckDB 1.5.x map element access on a
+// MAP<VARCHAR, VARCHAR> already returns a scalar VARCHAR.
+constexpr const char* kQuery =
+    "SELECT tags['storage_version']::VARCHAR AS sv "
+    "FROM duckdb_databases() "
+    "WHERE database_name = 'storage_version_test'";
+
+std::string GetStorageVersionTag(FlightSqlClient& sql_client,
+                                 const arrow::flight::FlightCallOptions& opts) {
+  auto info_res = sql_client.Execute(opts, kQuery);
+  EXPECT_TRUE(info_res.ok()) << info_res.status().ToString();
+  if (!info_res.ok()) return "";
+  auto& info = *info_res;
+
+  for (const auto& endpoint : info->endpoints()) {
+    auto reader_res = sql_client.DoGet(opts, endpoint.ticket);
+    EXPECT_TRUE(reader_res.ok()) << reader_res.status().ToString();
+    if (!reader_res.ok()) return "";
+    auto table_res = (*reader_res)->ToTable();
+    EXPECT_TRUE(table_res.ok()) << table_res.status().ToString();
+    if (!table_res.ok()) return "";
+    auto table = *table_res;
+    EXPECT_EQ(table->num_rows(), 1) << "duckdb_databases() returned no row "
+                                       "for the user database";
+    if (table->num_rows() != 1) return "";
+    auto col = table->column(0);
+    auto chunk = std::dynamic_pointer_cast<arrow::StringArray>(col->chunk(0));
+    EXPECT_NE(chunk, nullptr) << "Expected VARCHAR column for tag value";
+    if (!chunk) return "";
+    EXPECT_FALSE(chunk->IsNull(0)) << "tags['storage_version'] was unexpectedly NULL";
+    return chunk->GetString(0);
+  }
+  return "";
+}
+
+}  // namespace
+
+// ----------------------------------------------------------------------------
+// Fixture: server started with --storage-version=latest
+// ----------------------------------------------------------------------------
+class StorageVersionLatestFixture
+    : public gizmosql::testing::ServerTestFixture<StorageVersionLatestFixture> {
+ public:
+  static gizmosql::testing::TestServerConfig GetConfig() {
+    return {
+        .database_filename = "storage_version_test.db",
+        .port = 31390,
+        .health_port = 31391,
+        .username = "sv_user",
+        .password = "sv_password123",
+        .storage_version = "latest",
+    };
+  }
+};
+
+template <>
+std::shared_ptr<arrow::flight::sql::FlightSqlServerBase>
+    gizmosql::testing::ServerTestFixture<StorageVersionLatestFixture>::server_{};
+template <>
+std::thread
+    gizmosql::testing::ServerTestFixture<StorageVersionLatestFixture>::server_thread_{};
+template <>
+std::atomic<bool>
+    gizmosql::testing::ServerTestFixture<StorageVersionLatestFixture>::server_ready_{
+        false};
+template <>
+gizmosql::testing::TestServerConfig
+    gizmosql::testing::ServerTestFixture<StorageVersionLatestFixture>::config_{};
+
+TEST_F(StorageVersionLatestFixture, TagReflectsLatestStorageVersion) {
+  ASSERT_TRUE(IsServerReady()) << "Server not ready";
+
+  arrow::flight::FlightClientOptions options;
+  ASSERT_ARROW_OK_AND_ASSIGN(auto location,
+                             arrow::flight::Location::ForGrpcTcp("localhost", GetPort()));
+  ASSERT_ARROW_OK_AND_ASSIGN(auto client,
+                             arrow::flight::FlightClient::Connect(location, options));
+
+  arrow::flight::FlightCallOptions call_options;
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto bearer, client->AuthenticateBasicToken({}, GetUsername(), GetPassword()));
+  call_options.headers.push_back(bearer);
+
+  FlightSqlClient sql_client(std::move(client));
+
+  const std::string tag = GetStorageVersionTag(sql_client, call_options);
+  ASSERT_FALSE(tag.empty()) << "Did not retrieve a storage_version tag";
+
+  // With --storage-version=latest against a fresh DB, DuckDB stamps the file
+  // with the newest format the engine supports (currently v1.5.0+ on
+  // DuckDB 1.5.x). The exact tag floats with DuckDB upgrades, so we just
+  // assert it is NOT the v1.0.0+ baseline that a default-config DB would
+  // carry. That is the regression we care about: that --storage-version
+  // actually reaches DBConfig.options.serialization_compatibility.
+  EXPECT_NE(tag, "v1.0.0+")
+      << "Expected --storage-version=latest to bump the on-disk storage_version "
+         "tag past the v1.0.0+ default; got: " << tag;
+}
+
+// ----------------------------------------------------------------------------
+// Fixture: server started without --storage-version (default behavior)
+// ----------------------------------------------------------------------------
+class StorageVersionDefaultFixture
+    : public gizmosql::testing::ServerTestFixture<StorageVersionDefaultFixture> {
+ public:
+  static gizmosql::testing::TestServerConfig GetConfig() {
+    return {
+        .database_filename = "storage_version_test.db",
+        .port = 31392,
+        .health_port = 31393,
+        .username = "sv_user",
+        .password = "sv_password123",
+        // storage_version intentionally left empty
+    };
+  }
+};
+
+template <>
+std::shared_ptr<arrow::flight::sql::FlightSqlServerBase>
+    gizmosql::testing::ServerTestFixture<StorageVersionDefaultFixture>::server_{};
+template <>
+std::thread
+    gizmosql::testing::ServerTestFixture<StorageVersionDefaultFixture>::server_thread_{};
+template <>
+std::atomic<bool>
+    gizmosql::testing::ServerTestFixture<StorageVersionDefaultFixture>::server_ready_{
+        false};
+template <>
+gizmosql::testing::TestServerConfig
+    gizmosql::testing::ServerTestFixture<StorageVersionDefaultFixture>::config_{};
+
+TEST_F(StorageVersionDefaultFixture, TagIsBaselineWhenStorageVersionUnset) {
+  ASSERT_TRUE(IsServerReady()) << "Server not ready";
+
+  arrow::flight::FlightClientOptions options;
+  ASSERT_ARROW_OK_AND_ASSIGN(auto location,
+                             arrow::flight::Location::ForGrpcTcp("localhost", GetPort()));
+  ASSERT_ARROW_OK_AND_ASSIGN(auto client,
+                             arrow::flight::FlightClient::Connect(location, options));
+
+  arrow::flight::FlightCallOptions call_options;
+  ASSERT_ARROW_OK_AND_ASSIGN(
+      auto bearer, client->AuthenticateBasicToken({}, GetUsername(), GetPassword()));
+  call_options.headers.push_back(bearer);
+
+  FlightSqlClient sql_client(std::move(client));
+
+  const std::string tag = GetStorageVersionTag(sql_client, call_options);
+  ASSERT_FALSE(tag.empty()) << "Did not retrieve a storage_version tag";
+
+  // Pinned: control case. A fresh DB with default serialization_compatibility
+  // is tagged v1.0.0+, which is what proves the "latest" assertion above is
+  // actually testing something.
+  EXPECT_EQ(tag, "v1.0.0+")
+      << "Expected default storage_version tag to be v1.0.0+; got: " << tag;
+}


### PR DESCRIPTION
## Summary
- Expose DuckDB's `storage_version` config (the same option set by `duckdb -storage_version <ver>`) via a new `--storage-version` CLI flag, `GIZMOSQL_STORAGE_VERSION` env var (handy for container deployments), and a `storage_version` parameter on `RunFlightSQLServer()`. Maps onto `DBConfig::options::serialization_compatibility` via `SerializationCompatibility::FromString`.
- Useful for stamping new DB files with the newest on-disk format the engine supports (so newer DuckDB clients can attach at their newest level), or for capping at an older version for cross-version compatibility.
- Ignored for the SQLite backend, per design.

## Test plan
- [x] New `tests/integration/test_storage_version.cpp` with paired fixtures: asserts `duckdb_databases().tags['storage_version']` moves off the `v1.0.0+` baseline when `--storage-version=latest` is set, and stays at `v1.0.0+` when it isn't. Both green locally.
- [x] Verified the same invariant holds on the LTS channel (DuckDB v1.4.4 stamps `v1.4.0+`, default still `v1.0.0+`) — the "latest" test deliberately doesn't pin a stable-only version.
- [x] Smoke tested the CLI end-to-end: `--storage-version=latest` logs `DuckDB storage version set to: latest` and creates the file; `--storage-version=bogus` fails fast with DuckDB's full list of valid versions.
- [ ] CI green across the full matrix (Linux amd64/arm64, macOS arm64, Windows x64; stable + LTS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)