### PR TITLE
ci: publish per-asset SHA-256 sidecars on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -875,13 +875,31 @@ jobs:
             echo "WARNING: no matching CHANGELOG section for ${VERSION}; release will use auto-generated notes."
           fi
 
+      - name: Generate per-asset SHA-256 sidecars
+        # Emits a `<asset>.sha256` next to each release asset so downstream
+        # tools (the install.gizmosql.com curl|sh script in particular) can do
+        # a transit-integrity check without needing `gh attestation verify`.
+        # This is complementary to the Sigstore build attestations above —
+        # attestation is the stronger guarantee, this just lights up the
+        # bare-curl install path's existing verification branch.
+        run: |
+          set -euo pipefail
+          cd artifacts
+          for f in gizmosql_cli_*.zip GizmoSQL-*.msi; do
+            [ -f "$f" ] || continue
+            sha256sum "$f" | awk '{print $1"  "$2}' > "${f}.sha256"
+            echo "  $(cat "${f}.sha256")"
+          done
+
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
           body_path: release_notes.md
           files: |
             artifacts/gizmosql_cli_*.zip
+            artifacts/gizmosql_cli_*.zip.sha256
             artifacts/GizmoSQL-*.msi
+            artifacts/GizmoSQL-*.msi.sha256
             LICENSE
 
   update-image-manifest:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Per-asset SHA-256 sidecar files in GitHub releases.** The release CI now emits a `<asset>.sha256` next to every published CLI ZIP and MSI, so transit-integrity verification works for clients that fetch a release artifact without pulling the GitHub attestation manifest. In particular, the `curl -fsSL https://install.gizmosql.com/install.sh | sh` flow already had a verification branch keyed on a sibling `.sha256` file; previously it printed `(no published SHA-256 manifest for this release; skipping verification)` and fell back to no check. Complementary to (not a replacement for) the existing Sigstore build attestations on every release artifact — attestation remains the stronger guarantee for supply-chain provenance.
+
 ## [1.26.0] - 2026-05-09
 
 ### Added


### PR DESCRIPTION
## Summary
- Adds a CI step in the `create-release` job that emits a `<asset>.sha256` sidecar next to every CLI ZIP and MSI uploaded to the GitHub release.
- Lights up the existing transit-integrity verification branch in the [`install.gizmosql.com`](https://github.com/gizmodata/gizmosql-install/blob/main/install.sh) curl|sh script (which currently logs `(no published SHA-256 manifest for this release; skipping verification)` and falls back to no check).
- Complementary to (not a replacement for) the Sigstore build attestations we already publish for every release artifact. Attestation is the stronger supply-chain guarantee but requires the `gh` CLI to consume; the `.sha256` sidecars cover the bare-curl path that most install-script users hit.

## Test plan
- [ ] CI green on this PR (no functional change to PR-triggered jobs — the new step is in `create-release`, which is tag-gated and will only fire on the next `v*` tag push).
- [ ] After merging + cutting the next release, confirm the GitHub release page lists `gizmosql_cli_*.zip.sha256` and `GizmoSQL-*.msi.sha256` files alongside the binaries.
- [ ] Re-run `curl -fsSL https://install.gizmosql.com/install.sh | sh` against the new release and verify the `(no published SHA-256 manifest …)` warning is gone, replaced with a successful checksum-match line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)