### PR TITLE
Revert sha256 sidecars (paired with gizmosql-install#1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -875,31 +875,13 @@ jobs:
             echo "WARNING: no matching CHANGELOG section for ${VERSION}; release will use auto-generated notes."
           fi
 
-      - name: Generate per-asset SHA-256 sidecars
-        # Emits a `<asset>.sha256` next to each release asset so downstream
-        # tools (the install.gizmosql.com curl|sh script in particular) can do
-        # a transit-integrity check without needing `gh attestation verify`.
-        # This is complementary to the Sigstore build attestations above —
-        # attestation is the stronger guarantee, this just lights up the
-        # bare-curl install path's existing verification branch.
-        run: |
-          set -euo pipefail
-          cd artifacts
-          for f in gizmosql_cli_*.zip GizmoSQL-*.msi; do
-            [ -f "$f" ] || continue
-            sha256sum "$f" | awk '{print $1"  "$2}' > "${f}.sha256"
-            echo "  $(cat "${f}.sha256")"
-          done
-
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
           body_path: release_notes.md
           files: |
             artifacts/gizmosql_cli_*.zip
-            artifacts/gizmosql_cli_*.zip.sha256
             artifacts/GizmoSQL-*.msi
-            artifacts/GizmoSQL-*.msi.sha256
             LICENSE
 
   update-image-manifest:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.26.1] - 2026-05-10
-
 ### Added
 
 - **Per-asset SHA-256 sidecar files in GitHub releases.** The release CI now emits a `<asset>.sha256` next to every published CLI ZIP and MSI, so transit-integrity verification works for clients that fetch a release artifact without pulling the GitHub attestation manifest. In particular, the `curl -fsSL https://install.gizmosql.com/install.sh | sh` flow already had a verification branch keyed on a sibling `.sha256` file; previously it printed `(no published SHA-256 manifest for this release; skipping verification)` and fell back to no check. Complementary to (not a replacement for) the existing Sigstore build attestations on every release artifact — attestation remains the stronger guarantee for supply-chain provenance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- **Per-asset SHA-256 sidecar files in GitHub releases.** The release CI now emits a `<asset>.sha256` next to every published CLI ZIP and MSI, so transit-integrity verification works for clients that fetch a release artifact without pulling the GitHub attestation manifest. In particular, the `curl -fsSL https://install.gizmosql.com/install.sh | sh` flow already had a verification branch keyed on a sibling `.sha256` file; previously it printed `(no published SHA-256 manifest for this release; skipping verification)` and fell back to no check. Complementary to (not a replacement for) the existing Sigstore build attestations on every release artifact — attestation remains the stronger guarantee for supply-chain provenance.
-
 ## [1.26.0] - 2026-05-09
 
 ### Added


### PR DESCRIPTION
## Summary
Reverts the v1.26.1 release CI workaround. Pairs with [gizmosql-install#1](https://github.com/gizmodata/gizmosql-install/pull/1), which removes the verification block from the install scripts entirely.

Reverts:
- `7340d9f6` Release v1.26.1 (CHANGELOG-only)
- `a8e43a92` ci: publish per-asset SHA-256 sidecars on release (#169)

## Why
On reflection, the `.sha256` sidecar wasn't actually buying us security: with sole-owner write on this repo, the only threat it defended against was someone replacing a release asset, which requires owner-account compromise — at which point the attacker can replace the sidecar too. Supply-chain provenance is already covered by the Sigstore [build attestations](https://github.com/gizmodata/gizmosql/attestations) we publish for every release asset; users who want that level of verification can run `gh attestation verify <file> --repo gizmodata/gizmosql`.

Cleaner to remove the ceremony than to leave it in place looking like real verification. The matching installer PR drops the `(no published SHA-256 manifest …; skipping verification)` warning and the verification branch.

## Tag cleanup
The `v1.26.1` tag has been deleted (local + origin). Its release CI was cancelled before any GitHub release was created, so latest published release returns to `v1.26.0`. No follow-up release is required from this PR — it's a workflow-only revert.

## Test plan
- [ ] PR CI green (a no-op for non-tag pushes, since the reverted code only ran on `v*` tag pushes).
- [ ] After merge, `gh release view --repo gizmodata/gizmosql` still shows `v1.26.0` as latest, no orphaned `v1.26.1` tag in the refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)