### PR TITLE
feat: Windows ARM64 builds (native windows-11-arm runners, signed zips + MSIs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -607,7 +607,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=sccache `
             -DCMAKE_CXX_COMPILER_LAUNCHER=sccache `
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" `
-            -DVCPKG_TARGET_TRIPLET=$env:VCPKG_DEFAULT_TRIPLET `
+            -DVCPKG_TARGET_TRIPLET=${{ env.VCPKG_DEFAULT_TRIPLET }} `
             -DVCPKG_MANIFEST_MODE=OFF `
             -DGIZMOSQL_ENTERPRISE=ON `
             -DGIZMOSQL_DUCKDB_CHANNEL=${{ matrix.duckdb_channel }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,19 +505,32 @@ jobs:
           retention-days: 1
 
   build-project-windows:
-    name: Build Project - Windows (x64, ${{ matrix.duckdb_channel }})
-    runs-on: windows-2022
+    name: Build Project - Windows (${{ matrix.platform }}, ${{ matrix.duckdb_channel }})
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         duckdb_channel: [stable, lts]
+        # platform = release-artifact arch label (matches Linux naming);
+        # vc_arch = the MSVC/vcpkg arch token (vcvarsall arg, vcpkg triplet
+        # prefix, VC redist subdir, cache keys).
+        platform: [amd64, arm64]
+        include:
+          - platform: amd64
+            runner: windows-2022
+            vc_arch: x64
+          - platform: arm64
+            # Native ARM64 hosted runner (free for public repos). The image
+            # ships VS 2022 Enterprise + vcpkg at C:\vcpkg like windows-2022.
+            runner: windows-11-arm
+            vc_arch: arm64
     env:
-      VCPKG_DEFAULT_TRIPLET: x64-windows-static
+      VCPKG_DEFAULT_TRIPLET: ${{ matrix.vc_arch }}-windows-static
       # VS 2022 sets VCPKG_ROOT to its own vcpkg copy, conflicting with the
       # runner's vcpkg at C:\vcpkg. Override to suppress the mismatch warning.
       VCPKG_ROOT: C:\vcpkg
       bin_suffix: ${{ matrix.duckdb_channel == 'lts' && '_lts' || '' }}
-      unsigned_artifact: gizmosql-windows-amd64-unsigned${{ matrix.duckdb_channel == 'lts' && '-lts' || '' }}
+      unsigned_artifact: gizmosql-windows-${{ matrix.platform }}-unsigned${{ matrix.duckdb_channel == 'lts' && '-lts' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -545,26 +558,29 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ${{ env.VCPKG_ROOT }}/installed
-          key: vcpkg-x64-windows-static-${{ hashFiles('.github/workflows/ci.yml') }}
+          key: vcpkg-${{ env.VCPKG_DEFAULT_TRIPLET }}-${{ hashFiles('.github/workflows/ci.yml') }}
           restore-keys: |
-            vcpkg-x64-windows-static-
+            vcpkg-${{ env.VCPKG_DEFAULT_TRIPLET }}-
 
       - name: Install vcpkg dependencies
         if: steps.vcpkg-cache.outputs.cache-hit != 'true'
         run: |
-          & "$env:VCPKG_ROOT\vcpkg.exe" install boost-program-options boost-algorithm boost-uuid zlib openssl --triplet x64-windows-static --clean-after-build --x-install-root="$env:VCPKG_ROOT\installed"
+          & "$env:VCPKG_ROOT\vcpkg.exe" install boost-program-options boost-algorithm boost-uuid zlib openssl --triplet $env:VCPKG_DEFAULT_TRIPLET --clean-after-build --x-install-root="$env:VCPKG_ROOT\installed"
 
       - name: Save vcpkg cache
         if: steps.vcpkg-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v5
         with:
           path: ${{ env.VCPKG_ROOT }}/installed
-          key: vcpkg-x64-windows-static-${{ hashFiles('.github/workflows/ci.yml') }}
+          key: vcpkg-${{ env.VCPKG_DEFAULT_TRIPLET }}-${{ hashFiles('.github/workflows/ci.yml') }}
 
+      # ilammy passes the arch through to vcvarsall.bat verbatim. On the
+      # windows-11-arm runner `arm64` selects the native ARM64-hosted
+      # toolchain (host arch is auto-detected from PROCESSOR_ARCHITECTURE).
       - name: Setup MSVC
         uses: ilammy/msvc-dev-cmd@v1
         with:
-          arch: amd64
+          arch: ${{ matrix.vc_arch }}
 
       # vcvarsall.bat (run by ilammy/msvc-dev-cmd) exports VCPKG_ROOT pointing
       # to VS's own vcpkg copy, overriding our job-level env. Re-set it.
@@ -577,9 +593,9 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: build/third_party
-          key: arrow-windows-x64-${{ matrix.duckdb_channel }}-apache-arrow-23.0.1-${{ hashFiles('third_party/Arrow_CMakeLists.txt.in', 'third_party/patch_arrow.cmake') }}
+          key: arrow-windows-${{ matrix.vc_arch }}-${{ matrix.duckdb_channel }}-apache-arrow-23.0.1-${{ hashFiles('third_party/Arrow_CMakeLists.txt.in', 'third_party/patch_arrow.cmake') }}
           restore-keys: |
-            arrow-windows-x64-${{ matrix.duckdb_channel }}-apache-arrow-23.0.1-
+            arrow-windows-${{ matrix.vc_arch }}-${{ matrix.duckdb_channel }}-apache-arrow-23.0.1-
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -591,7 +607,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=sccache `
             -DCMAKE_CXX_COMPILER_LAUNCHER=sccache `
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT\scripts\buildsystems\vcpkg.cmake" `
-            -DVCPKG_TARGET_TRIPLET=x64-windows-static `
+            -DVCPKG_TARGET_TRIPLET=$env:VCPKG_DEFAULT_TRIPLET `
             -DVCPKG_MANIFEST_MODE=OFF `
             -DGIZMOSQL_ENTERPRISE=ON `
             -DGIZMOSQL_DUCKDB_CHANNEL=${{ matrix.duckdb_channel }}
@@ -604,11 +620,11 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: build/third_party
-          key: arrow-windows-x64-${{ matrix.duckdb_channel }}-apache-arrow-23.0.1-${{ hashFiles('third_party/Arrow_CMakeLists.txt.in', 'third_party/patch_arrow.cmake') }}
+          key: arrow-windows-${{ matrix.vc_arch }}-${{ matrix.duckdb_channel }}-apache-arrow-23.0.1-${{ hashFiles('third_party/Arrow_CMakeLists.txt.in', 'third_party/patch_arrow.cmake') }}
 
       - name: Copy VC++ runtime DLLs for DuckDB extension compatibility
         run: |
-          $crtDir = Join-Path $env:VCToolsRedistDir "x64\Microsoft.VC143.CRT"
+          $crtDir = Join-Path $env:VCToolsRedistDir "${{ matrix.vc_arch }}\Microsoft.VC143.CRT"
           Copy-Item "$crtDir\vcruntime140.dll" build\
           Copy-Item "$crtDir\vcruntime140_1.dll" build\
           Copy-Item "$crtDir\msvcp140.dll" build\
@@ -628,7 +644,7 @@ jobs:
             build/msvcp140.dll
 
   sign-windows:
-    name: Sign Windows (amd64, ${{ matrix.duckdb_channel }})
+    name: Sign Windows (${{ matrix.platform }}, ${{ matrix.duckdb_channel }})
     needs: build-project-windows
     runs-on: windows-latest
     environment: production
@@ -636,10 +652,11 @@ jobs:
       fail-fast: false
       matrix:
         duckdb_channel: [stable, lts]
+        platform: [amd64, arm64]
     env:
-      unsigned_artifact: gizmosql-windows-amd64-unsigned${{ matrix.duckdb_channel == 'lts' && '-lts' || '' }}
-      signed_artifact: gizmosql-windows-amd64-signed${{ matrix.duckdb_channel == 'lts' && '-lts' || '' }}
-      cli_zip_name: gizmosql_cli_windows_amd64${{ matrix.duckdb_channel == 'lts' && '_lts' || '' }}.zip
+      unsigned_artifact: gizmosql-windows-${{ matrix.platform }}-unsigned${{ matrix.duckdb_channel == 'lts' && '-lts' || '' }}
+      signed_artifact: gizmosql-windows-${{ matrix.platform }}-signed${{ matrix.duckdb_channel == 'lts' && '-lts' || '' }}
+      cli_zip_name: gizmosql_cli_windows_${{ matrix.platform }}${{ matrix.duckdb_channel == 'lts' && '_lts' || '' }}.zip
     permissions:
       id-token: write
       contents: read
@@ -674,11 +691,17 @@ jobs:
               $_.FullName
           }
 
+      # Include the VC++ runtime DLLs (already Microsoft-signed) alongside our
+      # signed exes: the MSI job packages them from this artifact so the DLL
+      # arch always matches the binaries (the MSI runner's own System32 DLLs
+      # are x64 and would silently break the arm64 installer).
       - name: Upload signed executables
         uses: actions/upload-artifact@v7
         with:
           name: ${{ env.signed_artifact }}
-          path: unsigned/**/*.exe
+          path: |
+            unsigned/**/*.exe
+            unsigned/**/*.dll
           if-no-files-found: error
 
       - name: Create signed zip
@@ -692,7 +715,7 @@ jobs:
           path: ${{ env.cli_zip_name }}
 
   build-msi:
-    name: Build MSI (amd64, ${{ matrix.duckdb_channel }})
+    name: Build MSI (${{ matrix.platform }}, ${{ matrix.duckdb_channel }})
     needs: sign-windows
     runs-on: windows-latest
     environment: production
@@ -700,11 +723,14 @@ jobs:
       fail-fast: false
       matrix:
         duckdb_channel: [stable, lts]
+        platform: [amd64, arm64]
     env:
-      signed_artifact: gizmosql-windows-amd64-signed${{ matrix.duckdb_channel == 'lts' && '-lts' || '' }}
-      msi_artifact: GizmoSQL-amd64${{ matrix.duckdb_channel == 'lts' && '-lts' || '' }}-msi.zip
-      msi_filename: GizmoSQL-amd64${{ matrix.duckdb_channel == 'lts' && '-lts' || '' }}.msi
+      signed_artifact: gizmosql-windows-${{ matrix.platform }}-signed${{ matrix.duckdb_channel == 'lts' && '-lts' || '' }}
+      msi_artifact: GizmoSQL-${{ matrix.platform }}${{ matrix.duckdb_channel == 'lts' && '-lts' || '' }}-msi.zip
+      msi_filename: GizmoSQL-${{ matrix.platform }}${{ matrix.duckdb_channel == 'lts' && '-lts' || '' }}.msi
       bin_suffix: ${{ matrix.duckdb_channel == 'lts' && '_lts' || '' }}
+      # WiX arch token: x64 for amd64, arm64 as-is.
+      wix_arch: ${{ matrix.platform == 'arm64' && 'arm64' || 'x64' }}
     permissions:
       id-token: write
       contents: read
@@ -712,17 +738,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # The signed artifact already carries the arch-matched VC++ runtime
+      # DLLs (vcruntime140, vcruntime140_1, msvcp140) from the build runner's
+      # VC redist — do NOT copy them from this runner's System32, which is
+      # always x64.
       - name: Download signed executables
         uses: actions/download-artifact@v8
         with:
           name: ${{ env.signed_artifact }}
           path: installer/bin
-
-      - name: Copy VC++ runtime DLLs
-        run: |
-          Copy-Item "$env:SystemRoot\System32\vcruntime140.dll" installer\bin\
-          Copy-Item "$env:SystemRoot\System32\vcruntime140_1.dll" installer\bin\
-          Copy-Item "$env:SystemRoot\System32\msvcp140.dll" installer\bin\
 
       - name: Stage binaries for WiX (LTS strips the _lts suffix)
         # GizmoSQL.wxs references gizmosql_server.exe / gizmosql_client.exe
@@ -769,7 +793,7 @@ jobs:
         run: |
           wix build `
             "${{ github.workspace }}\installer\GizmoSQL.wxs" `
-            -arch x64 `
+            -arch ${{ env.wix_arch }} `
             -b BinDir="${{ github.workspace }}\installer\bin" `
             -b "${{ github.workspace }}\installer" `
             -o "${{ github.workspace }}\installer\${{ env.msi_filename }}" `
@@ -856,6 +880,16 @@ jobs:
         with:
           subject-path: artifacts/GizmoSQL-amd64.msi
 
+      - name: Attest build provenance - Windows ARM64
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: artifacts/gizmosql_cli_windows_arm64.zip
+
+      - name: Attest build provenance - Windows ARM64 MSI
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: artifacts/GizmoSQL-arm64.msi
+
       # ----- LTS channel artifacts -----
       - name: Attest build provenance - Linux AMD64 (LTS)
         uses: actions/attest-build-provenance@v4
@@ -881,6 +915,16 @@ jobs:
         uses: actions/attest-build-provenance@v4
         with:
           subject-path: artifacts/GizmoSQL-amd64-lts.msi
+
+      - name: Attest build provenance - Windows ARM64 (LTS)
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: artifacts/gizmosql_cli_windows_arm64_lts.zip
+
+      - name: Attest build provenance - Windows ARM64 MSI (LTS)
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: artifacts/GizmoSQL-arm64-lts.msi
 
       - name: Extract release notes from CHANGELOG.md
         id: changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Windows ARM64 builds** — native `arm64` Windows binaries (for Snapdragon X-class and other Windows-on-Arm machines) now ship alongside the existing `amd64` ones, in both the stable and LTS channels: signed CLI zips (`gizmosql_cli_windows_arm64.zip`, `gizmosql_cli_windows_arm64_lts.zip`) and signed MSI installers (`GizmoSQL-arm64.msi`, `GizmoSQL-arm64-lts.msi`), all with build-provenance attestations. Built natively on GitHub's `windows-11-arm` hosted runners (no cross-compilation), with the integration test suite running on ARM64 in CI. The MSI now packages the VC++ runtime DLLs captured from the build runner's VC redist (matching the binary architecture) instead of the MSI runner's x64 `System32` copies.
+
 ### Changed
 
 - **Quick Start version auto-sync now happens at docs-publish time instead of via a commit to `main`.** The `deploy-docs` workflow runs `scripts/update_docs_version.sh` against the latest release tag right before publishing GitHub Pages, and is triggered after a successful release via `workflow_run`. This replaces the `sync-docs-version` CI job, which tried to push the version bump to `main` and was rejected by the branch-protection ruleset (`github-actions[bot]` is not exempt). The live docs always reflect the newest release with no secrets and no push to the protected branch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,14 @@ When adding a new configuration parameter, update these locations in order:
    - `RunFlightSQLServer()` call to `CreateFlightSQLServer()`
 4. `tests/integration/test_server_fixture.h` - Add to `TestServerConfig` and forward declaration
 
+**Gotcha — `RunFlightSQLServer()` has FOUR positional callers.** If you add or reorder a parameter (not just append a defaulted one), every positional call site must be updated in lockstep or the build breaks with `no matching function for call to 'RunFlightSQLServer'`. The callers are:
+1. `src/gizmosql_server.cpp` (the CLI)
+2. `ios/GizmoSQL/GizmoSQL/Bridging/gizmosql_ios_bridge.cpp` (the iOS app — **Core build, not in the local enterprise `build/`, so a mismatch here only surfaces in iOS CI**)
+3. `tests/integration/test_enterprise_gating.cpp`
+4. `tests/integration/test_max_metadata_size.cpp`
+
+Also: any param used only inside the `#ifdef GIZMOSQL_ENTERPRISE` block needs a `(void)param;` in the `#else` branch of `RunFlightSQLServer()` (next to `(void)license_key_file;`), or Core/iOS builds fail `-Werror=unused-parameter`.
+
 ### Bumping DuckDB (iOS extension sync)
 When upgrading DuckDB in `third_party/DuckDB_CMakeLists.txt.in`, the out-of-tree extensions pinned in `third_party/duckdb_extensions.cmake` for the iOS build (inside the `if(GIZMOSQL_IOS)` block) **must** be re-synced to DuckDB's own pins for the new version. DuckDB ships those pins in `<duckdb_repo>/.github/config/extensions/<name>.cmake`. Cross-check **every** extension we pin (ducklake, httpfs, postgres_scanner, and any added later) — not just the one that motivated the bump — and carry over any new clauses like `SUBMODULES`, since the extension's own build may now depend on them. Mismatched pins fail to link at build time (`ld: library 'X_extension' not found`) or, worse, produce a silently broken binary. After bumping, delete `ios/build/ios-arm64/third_party/src/duckdb_project*` and `ios/build/ios-arm64/duckdb/` and re-run `ios/scripts/build-ios-libs.sh` so the ExternalProject re-clones at the new tag (git-shallow clones can't simply `git fetch` new tags). Also re-validate the Phase 2.5 patches in `ios/scripts/build-ios-libs.sh`: if upstream has subsumed something we used to patch in (e.g. postgres_scanner now ships its own `build_static_extension` call), our patch will collide with `add_library cannot create target ... already exists` — drop it from Phase 2.5.
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ GIZMOSQL_PASSWORD="gizmosql_password" gizmosql_server --database-filename your.d
 
 ### Option 4: Windows Installer (MSI)
 
-Download the latest MSI installer from the [GitHub Releases](https://github.com/gizmodata/gizmosql/releases) page. The installer adds `gizmosql_server.exe` and `gizmosql_client.exe` to `C:\Program Files\GizmoSQL` and updates the system PATH.
+Download the latest MSI installer from the [GitHub Releases](https://github.com/gizmodata/gizmosql/releases) page — `GizmoSQL-amd64.msi` for x64 machines, or `GizmoSQL-arm64.msi` for Windows on Arm (e.g. Snapdragon X-class devices). The installer adds `gizmosql_server.exe` and `gizmosql_client.exe` to `C:\Program Files\GizmoSQL` and updates the system PATH.
 
 Then run the server from PowerShell or Command Prompt:
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -338,7 +338,11 @@ GIZMOSQL_PASSWORD="gizmosql_password" gizmosql_server --database-filename your.d
 Download (and unzip) the latest release of the **gizmosql_server** CLI executable from these currently supported platforms:
 [Linux x86-64](https://github.com/gizmodata/gizmosql/releases/latest/download/gizmosql_cli_linux_amd64.zip)
 [Linux arm64](https://github.com/gizmodata/gizmosql/releases/latest/download/gizmosql_cli_linux_arm64.zip)
-[MacOS arm64](https://github.com/gizmodata/gizmosql/releases/latest/download/gizmosql_cli_macos_arm64.zip)   
+[MacOS arm64](https://github.com/gizmodata/gizmosql/releases/latest/download/gizmosql_cli_macos_arm64.zip)
+[Windows x64](https://github.com/gizmodata/gizmosql/releases/latest/download/gizmosql_cli_windows_amd64.zip)
+[Windows arm64](https://github.com/gizmodata/gizmosql/releases/latest/download/gizmosql_cli_windows_arm64.zip)
+
+> **Windows:** prefer the signed MSI installers — `GizmoSQL-amd64.msi` (x64) or `GizmoSQL-arm64.msi` (Windows on Arm, e.g. Snapdragon X-class) — from the [GitHub Releases](https://github.com/gizmodata/gizmosql/releases) page. The installer adds the binaries to `C:\Program Files\GizmoSQL` and updates the system PATH.
 
 Then from a terminal - you can run:
 ```bash

--- a/docs/lts_channel.md
+++ b/docs/lts_channel.md
@@ -57,8 +57,8 @@ LTS artifacts are suffixed so they coexist with stable on the same machine, imag
 |-------------------|------------------------------------------------|--------------------------------------------------|
 | Server binary     | `gizmosql_server`                              | `gizmosql_server_lts`                            |
 | Client binary     | `gizmosql_client`                              | `gizmosql_client_lts`                            |
-| Linux/macOS zip   | `gizmosql_cli_<os>_<arch>.zip`                 | `gizmosql_cli_<os>_<arch>_lts.zip`               |
-| Windows MSI       | `GizmoSQL-amd64.msi`                           | `GizmoSQL-amd64-lts.msi`                         |
+| CLI zip           | `gizmosql_cli_<os>_<arch>.zip`                 | `gizmosql_cli_<os>_<arch>_lts.zip`               |
+| Windows MSI       | `GizmoSQL-<arch>.msi` *(amd64, arm64)*         | `GizmoSQL-<arch>-lts.msi` *(amd64, arm64)*       |
 | Docker (Hub)      | `gizmodata/gizmosql:<ver>` *(+ `-slim`)*       | `gizmodata/gizmosql-lts:<ver>` *(+ `-slim`)*     |
 | Docker (GHCR)     | `ghcr.io/gizmodata/gizmosql:<ver>`             | `ghcr.io/gizmodata/gizmosql-lts:<ver>`           |
 | Homebrew formula  | `gizmodata/tap` → `gizmosql`                   | `gizmodata/tap` → `gizmosql-lts` *(same tap)*    |


### PR DESCRIPTION
## Summary

- Widens the Windows **build / sign / MSI** jobs into an arch matrix (`amd64` + `arm64`, both DuckDB channels). The arm64 leg builds **natively** on GitHub's `windows-11-arm` hosted runners (free for public repos) — no cross-compilation — using the `arm64-windows-static` vcpkg triplet and the native ARM64 MSVC toolchain via `vcvarsall arm64`.
- New release artifacts, all Azure-signed with build-provenance attestations: `gizmosql_cli_windows_arm64.zip`, `gizmosql_cli_windows_arm64_lts.zip`, `GizmoSQL-arm64.msi`, `GizmoSQL-arm64-lts.msi`.
- **Fixes a latent MSI packaging bug**: the MSI job copied `vcruntime140*.dll`/`msvcp140.dll` from the MSI runner's `System32` (always x64). The arch-matched VC redist DLLs now ride through the signed artifact from the build runner — required for a working arm64 installer.
- Docs: README MSI section now lists both arches; LTS artifact-naming table generalized; CHANGELOG entry added.

## Verification

Full CI run green across all 20 jobs: https://github.com/gizmodata/gizmosql/actions/runs/27428022430

The integration suite runs natively on ARM64 in CI with an identical profile to amd64 (384 ran / 301 passed / 83 skipped, zero failures) — and finished faster than the x64 runner (86.8s vs 102.7s).

## Follow-up (separate repo)

The `install.gizmosql.com` picker script should learn to offer the new `windows_arm64` artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)