### PR TITLE
fix: JWKS/OAuth HTTPS TLS verification on portable/Docker builds (system CA bundle)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,15 +309,27 @@ jobs:
             bash "$PWD/scripts/build_portable_linux.sh" ${{ matrix.duckdb_channel }} build
           sudo chown -R "$(id -u):$(id -g)" build
 
-      - name: Smoke test out-of-the-box startup (Raspberry Pi OS userland + Amazon Linux 2023)
-        # debian:bookworm-slim is the same userland as Raspberry Pi OS
-        # (bookworm). Both targets were broken before the manylinux build
-        # (binaries needed GLIBC_2.38 / GLIBCXX_3.4.32).
+      - name: Smoke test startup + outbound TLS trust (Raspberry Pi OS userland + Amazon Linux 2023)
+        # Two guarantees on the actual portable binary, on both CA-layout families
+        # (Debian /etc/ssl/certs and RHEL/Amazon /etc/pki/tls):
+        #   1. starts out of the box on an old-glibc distro (debian:bookworm-slim
+        #      is the Raspberry Pi OS userland) — both targets needed GLIBC_2.38 /
+        #      GLIBCXX_3.4.32 before the manylinux build.
+        #   2. outbound HTTPS verifies against the *system* CA bundle. This guards
+        #      the v1.30.0 regression where the statically-linked OpenSSL's
+        #      compiled-in CA path (OPENSSLDIR) is a build-time dir that doesn't
+        #      exist at runtime, so JWKS/OAuth TLS verification failed. If the CA
+        #      probe ever regresses, --verify-tls exits non-zero and this fails.
         run: |
+          OIDC="https://token.actions.githubusercontent.com/.well-known/openid-configuration"
           docker run --rm -v "$PWD/build:/bin-under-test:ro" debian:bookworm-slim bash -c \
-            "apt-get update -qq >/dev/null && apt-get install -y -qq libcurl4 >/dev/null && /bin-under-test/gizmosql_server${{ env.bin_suffix }} --version"
+            "apt-get update -qq >/dev/null && apt-get install -y -qq libcurl4 ca-certificates >/dev/null && \
+             /bin-under-test/gizmosql_server${{ env.bin_suffix }} --version && \
+             /bin-under-test/gizmosql_server${{ env.bin_suffix }} --verify-tls '$OIDC'"
           docker run --rm -v "$PWD/build:/bin-under-test:ro" amazonlinux:2023 bash -c \
-            "/bin-under-test/gizmosql_server${{ env.bin_suffix }} --version"
+            "(rpm -q ca-certificates >/dev/null 2>&1 || dnf install -y -q ca-certificates >/dev/null) && \
+             /bin-under-test/gizmosql_server${{ env.bin_suffix }} --version && \
+             /bin-under-test/gizmosql_server${{ env.bin_suffix }} --verify-tls '$OIDC'"
 
       - name: Save Arrow cache
         if: steps.arrow-cache.outputs.cache-hit != 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Outbound HTTPS (JWKS / OAuth) now verifies TLS against the system CA bundle — fixes `SSL server verification failed` on the portable/Docker builds.** Since v1.30.0 (the portable-Linux / `manylinux_2_28` migration), the release binaries statically link a self-built OpenSSL whose compiled-in default CA directory (`OPENSSLDIR`) is a build-time path that does not exist at runtime. As a result, every outbound HTTPS request from the server-side **JWKS/OIDC discovery + key fetch** and **OAuth token exchange**, and the **client's OAuth login flow**, failed certificate verification — e.g. `Failed to auto-discover JWKS from issuer …: SSL server verification failed`. (`curl` inside the same container worked because it uses the distro's OpenSSL.) All three cpp-httplib clients now explicitly load the system CA bundle (`/etc/ssl/certs/ca-certificates.crt`, `/etc/pki/tls/certs/ca-bundle.crt`, …, honoring `$SSL_CERT_FILE`), so TLS verification works on Debian/Ubuntu, RHEL/Amazon Linux, SUSE, and macOS regardless of the static OpenSSL's `OPENSSLDIR`. The Docker images also set `SSL_CERT_FILE`/`SSL_CERT_DIR` as defense-in-depth. Adds a `gizmosql_server --verify-tls <url>` diagnostic (a verified HTTPS GET via the same path), now exercised against a real public OIDC endpoint in the Debian + Amazon Linux portable-binary smoke tests so a CA-trust regression turns CI red.
+
 ## [1.31.0] - 2026-06-17
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -824,6 +824,7 @@ set_target_properties(gizmosql_client PROPERTIES
 target_include_directories(gizmosql_client
         PRIVATE
         ${CMAKE_SOURCE_DIR}/src/common/include
+        ${CMAKE_SOURCE_DIR}/src/common/include/detail
         ${CMAKE_SOURCE_DIR}/src/client
         ${HTTPLIB_INCLUDE_DIR}
 )

--- a/Dockerfile-slim.ci
+++ b/Dockerfile-slim.ci
@@ -44,4 +44,10 @@ RUN chmod +x /usr/local/bin/gizmosql_client
 EXPOSE 31337
 EXPOSE 31339
 
+# Point OpenSSL's default-verify-paths at the distro CA bundle (the statically
+# linked gizmosql OpenSSL bakes in a build-time OPENSSLDIR that isn't present at
+# runtime). Belt-and-suspenders alongside the binary's own CA probe.
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
+    SSL_CERT_DIR=/etc/ssl/certs
+
 ENTRYPOINT ["scripts/start_gizmosql_slim.sh"]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -135,6 +135,14 @@ RUN python3 -m venv ${VIRTUAL_ENV} && \
 # Set the PATH so that the Python Virtual environment is referenced for subsequent RUN steps (hat tip: https://pythonspeed.com/articles/activate-virtualenv-dockerfile/)
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
+# Point OpenSSL's default-verify-paths at the distro CA bundle. The portable
+# gizmosql binaries statically link a self-built OpenSSL whose compiled-in
+# OPENSSLDIR is a build-time path that doesn't exist here; the binary's own CA
+# probe handles this, and these env vars are belt-and-suspenders that also cover
+# any other OpenSSL consumer in the image.
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
+    SSL_CERT_DIR=/etc/ssl/certs
+
 # Copy the scripts directory into the image (we copy directory-by-directory in order to maximize Docker caching)
 COPY --chown=app_user:app_user scripts scripts
 

--- a/src/client/oauth_flow.cpp
+++ b/src/client/oauth_flow.cpp
@@ -31,6 +31,7 @@
 #define CPPHTTPLIB_OPENSSL_SUPPORT
 #include <httplib.h>
 #include <nlohmann/json.hpp>
+#include "system_ca_certs.h"
 
 namespace gizmosql::client {
 
@@ -62,6 +63,7 @@ arrow::Result<std::pair<std::string, std::string>> OAuthFlow::Initiate(
   httplib::Client cli(oauth_base_url);
   cli.set_connection_timeout(10);
   cli.set_read_timeout(10);
+  if (auto ca = gizmosql::FindSystemCaCertFile()) cli.set_ca_cert_path(ca->c_str());
 
   auto res = cli.Get("/oauth/initiate");
   if (!res) {
@@ -120,6 +122,7 @@ arrow::Result<std::string> OAuthFlow::PollForToken(
   httplib::Client cli(oauth_base_url);
   cli.set_connection_timeout(10);
   cli.set_read_timeout(10);
+  if (auto ca = gizmosql::FindSystemCaCertFile()) cli.set_ca_cert_path(ca->c_str());
 
   auto start = std::chrono::steady_clock::now();
   std::string poll_path = "/oauth/token/" + uuid;

--- a/src/common/include/detail/system_ca_certs.h
+++ b/src/common/include/detail/system_ca_certs.h
@@ -1,0 +1,66 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstdlib>
+#include <fstream>
+#include <optional>
+#include <string>
+
+namespace gizmosql {
+
+// Finds the path to the first existing system CA-certificate bundle file, or
+// std::nullopt if none is found.
+//
+// Why this exists: the portable Linux release binaries statically link a
+// self-built OpenSSL (see scripts/build_portable_linux.sh) whose compiled-in
+// default CA directory (OPENSSLDIR) is a *build-time* path that does not exist
+// at runtime. As a result, OpenSSL's default-verify-paths logic finds no trust
+// store and every outbound HTTPS verification fails ("SSL server verification
+// failed"). To fix this robustly across distros, our cpp-httplib clients call
+// `client.set_ca_cert_path(FindSystemCaCertFile())` so the system bundle is used
+// regardless of OPENSSLDIR.
+//
+// Resolution order:
+//   1. $SSL_CERT_FILE (operator override; also honored by OpenSSL itself),
+//   2. well-known bundle locations for Debian/Ubuntu/Alpine, RHEL/Amazon Linux,
+//      OpenSUSE, and macOS (including Homebrew OpenSSL).
+inline std::optional<std::string> FindSystemCaCertFile() {
+  if (const char* env = std::getenv("SSL_CERT_FILE")) {
+    if (env[0] != '\0') {
+      std::ifstream f(env);
+      if (f.good()) return std::string(env);
+    }
+  }
+  static const char* kPaths[] = {
+      "/etc/ssl/certs/ca-certificates.crt",    // Debian, Ubuntu, Alpine
+      "/etc/pki/tls/certs/ca-bundle.crt",      // RHEL, CentOS, Fedora, Amazon Linux
+      "/etc/ssl/ca-bundle.pem",                // OpenSUSE
+      "/etc/pki/tls/cacert.pem",               // OpenELEC
+      "/etc/ssl/cert.pem",                     // macOS, Alpine, BSD
+      "/usr/local/etc/openssl@3/cert.pem",     // macOS Homebrew (Intel)
+      "/opt/homebrew/etc/openssl@3/cert.pem",  // macOS Homebrew (Apple Silicon)
+  };
+  for (const char* path : kPaths) {
+    std::ifstream f(path);
+    if (f.good()) return std::string(path);
+  }
+  return std::nullopt;
+}
+
+}  // namespace gizmosql

--- a/src/enterprise/jwks/jwks_manager.cpp
+++ b/src/enterprise/jwks/jwks_manager.cpp
@@ -5,6 +5,7 @@
 #include "jwks_manager.h"
 
 #include <nlohmann/json.hpp>
+#include <iostream>
 #include <sstream>
 
 #define CPPHTTPLIB_OPENSSL_SUPPORT
@@ -12,6 +13,49 @@
 
 #include "jwt-cpp/jwt.h"
 #include "gizmosql_logging.h"
+#include "system_ca_certs.h"
+
+namespace gizmosql {
+
+// HTTPS reachability/trust self-check (used by `gizmosql_server --verify-tls`
+// and the CI smoke test). Performs a single GET against `url` using the system
+// CA bundle, exactly like the JWKS/OAuth clients. Returns 0 on a successful
+// verified HTTPS response, 1 otherwise (printing the reason). Lives here because
+// this TU already has cpp-httplib + OpenSSL wired in.
+int VerifyTlsEndpoint(const std::string& url) {
+  // Split scheme://host[:port]/path — httplib::Client wants scheme+host+port.
+  const auto scheme_end = url.find("://");
+  const std::string scheme =
+      scheme_end == std::string::npos ? "https" : url.substr(0, scheme_end);
+  const std::string after =
+      scheme_end == std::string::npos ? url : url.substr(scheme_end + 3);
+  const auto slash = after.find('/');
+  const std::string base =
+      scheme + "://" + (slash == std::string::npos ? after : after.substr(0, slash));
+  const std::string path = slash == std::string::npos ? "/" : after.substr(slash);
+
+  httplib::Client client(base.c_str());
+  client.set_follow_location(true);
+  client.set_connection_timeout(std::chrono::seconds(10));
+  client.set_read_timeout(std::chrono::seconds(10));
+  if (auto ca = gizmosql::FindSystemCaCertFile()) {
+    client.set_ca_cert_path(ca->c_str());
+    std::cout << "verify-tls: using CA bundle " << *ca << "\n";
+  } else {
+    std::cout << "verify-tls: WARNING no system CA bundle found "
+                 "(set SSL_CERT_FILE)\n";
+  }
+  auto res = client.Get(path.c_str());
+  if (!res) {
+    std::cout << "verify-tls: FAILED for " << url << ": "
+              << httplib::to_string(res.error()) << "\n";
+    return 1;
+  }
+  std::cout << "verify-tls: OK " << url << " -> HTTP " << res->status << "\n";
+  return 0;
+}
+
+}  // namespace gizmosql
 
 namespace gizmosql::enterprise {
 
@@ -271,6 +315,12 @@ arrow::Result<std::string> JwksManager::HttpGet(const std::string& url) {
   client.set_follow_location(true);
   client.set_connection_timeout(std::chrono::seconds(10));
   client.set_read_timeout(std::chrono::seconds(10));
+  // Use the system CA bundle explicitly. Our portable binaries statically link
+  // an OpenSSL whose compiled-in default CA path does not exist at runtime, so
+  // relying on OpenSSL's default-verify-paths would fail every HTTPS handshake.
+  if (auto ca = gizmosql::FindSystemCaCertFile()) {
+    client.set_ca_cert_path(ca->c_str());
+  }
 
   auto res = client.Get(path);
   if (!res) {

--- a/src/enterprise/oauth/oauth_http_server.cpp
+++ b/src/enterprise/oauth/oauth_http_server.cpp
@@ -19,6 +19,7 @@
 #include "jwt-cpp/jwt.h"
 #include "gizmosql_logging.h"
 #include "gizmosql_security.h"
+#include "system_ca_certs.h"
 
 namespace gizmosql::enterprise {
 
@@ -390,6 +391,12 @@ arrow::Result<std::string> OAuthHttpServer::ExchangeCodeForTokens(
   client.set_follow_location(true);
   client.set_connection_timeout(std::chrono::seconds(10));
   client.set_read_timeout(std::chrono::seconds(10));
+  // Explicitly use the system CA bundle (the statically-linked OpenSSL's
+  // compiled-in default CA path does not exist at runtime — see
+  // system_ca_certs.h).
+  if (auto ca = gizmosql::FindSystemCaCertFile()) {
+    client.set_ca_cert_path(ca->c_str());
+  }
 
   // Build POST body
   httplib::Params params;

--- a/src/gizmosql_server.cpp
+++ b/src/gizmosql_server.cpp
@@ -24,6 +24,15 @@
 namespace po = boost::program_options;
 namespace fs = std::filesystem;
 
+#ifdef GIZMOSQL_ENTERPRISE
+// Defined in src/enterprise/jwks/jwks_manager.cpp (where cpp-httplib + OpenSSL
+// are already wired). Performs a single verified HTTPS GET using the system CA
+// bundle — the same path the JWKS/OAuth clients use — and returns 0/1.
+namespace gizmosql {
+int VerifyTlsEndpoint(const std::string& url);
+}
+#endif
+
 int main(int argc, char** argv) {
   std::vector<std::string> tls_token_values;
 
@@ -33,6 +42,11 @@ int main(int argc, char** argv) {
     desc.add_options()
             ("help", "produce this help message")
             ("version", "Print the version and exit")
+            ("verify-tls", po::value<std::string>(),
+             "Diagnostic: perform a verified HTTPS GET to the given URL using the "
+             "system CA trust store (the same path JWKS/OAuth use) and exit "
+             "(0 = success, 1 = failure). Useful to check outbound TLS/CA in a "
+             "container, e.g. --verify-tls https://issuer/.well-known/openid-configuration")
             ("backend,B", po::value<std::string>()->default_value("duckdb"),
              "Specify the database backend. Allowed options: duckdb, sqlite.")
             ("hostname,H", po::value<std::string>()->default_value(""),
@@ -286,6 +300,15 @@ int main(int argc, char** argv) {
   if (vm.count("version")) {
     std::cout << "GizmoSQL Server CLI: " << GIZMOSQL_SERVER_VERSION << "\n";
     return 0;
+  }
+
+  if (vm.count("verify-tls")) {
+#ifdef GIZMOSQL_ENTERPRISE
+    return gizmosql::VerifyTlsEndpoint(vm["verify-tls"].as<std::string>());
+#else
+    std::cerr << "--verify-tls requires the GizmoSQL Enterprise edition\n";
+    return 1;
+#endif
   }
 
   std::string backend_str = vm["backend"].as<std::string>();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ set(GIZMOSQL_CORE_TEST_SRCS
         integration/test_max_metadata_size.cpp
         integration/test_graceful_shutdown.cpp
         integration/test_admin_command_guard.cpp
+        integration/test_system_ca_certs.cpp
         integration/test_session_options_probe.cpp
         integration/test_set_query_log_level.cpp
         integration/test_sqlite_backend.cpp

--- a/tests/integration/test_system_ca_certs.cpp
+++ b/tests/integration/test_system_ca_certs.cpp
@@ -1,0 +1,95 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+
+// Unit tests for the system CA-bundle probe used to give our cpp-httplib
+// HTTPS clients (JWKS/OAuth) an explicit trust store, because the portable
+// static OpenSSL's compiled-in CA path doesn't exist at runtime. The
+// end-to-end TLS behavior on the actual portable binary is guarded by the
+// `--verify-tls` smoke test in CI; this guards the path-resolution logic.
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+#include "system_ca_certs.h"
+
+namespace {
+
+// RAII for an env var (set on construct, restore on destruct).
+class ScopedEnv {
+ public:
+  ScopedEnv(const char* name, const char* value) : name_(name) {
+    const char* prev = std::getenv(name);
+    had_prev_ = prev != nullptr;
+    if (had_prev_) prev_ = prev;
+    setenv(name, value, /*overwrite=*/1);
+  }
+  ~ScopedEnv() {
+    if (had_prev_) {
+      setenv(name_, prev_.c_str(), 1);
+    } else {
+      unsetenv(name_);
+    }
+  }
+
+ private:
+  const char* name_;
+  bool had_prev_ = false;
+  std::string prev_;
+};
+
+}  // namespace
+
+// SSL_CERT_FILE, when it points at an existing file, takes precedence.
+TEST(SystemCaCerts, RespectsSslCertFileEnv) {
+  // Create a temp file to stand in for a CA bundle.
+  std::string tmp = std::string(std::tmpnam(nullptr)) + "_ca.pem";
+  {
+    std::ofstream f(tmp);
+    f << "# test bundle\n";
+  }
+  {
+    ScopedEnv env("SSL_CERT_FILE", tmp.c_str());
+    auto found = gizmosql::FindSystemCaCertFile();
+    ASSERT_TRUE(found.has_value());
+    EXPECT_EQ(*found, tmp);
+  }
+  std::remove(tmp.c_str());
+}
+
+// A non-existent SSL_CERT_FILE is ignored; the probe falls through to the
+// system bundle list.
+TEST(SystemCaCerts, IgnoresNonexistentSslCertFileEnv) {
+  ScopedEnv env("SSL_CERT_FILE", "/definitely/does/not/exist/ca.pem");
+  auto found = gizmosql::FindSystemCaCertFile();
+  if (found.has_value()) {
+    EXPECT_NE(*found, "/definitely/does/not/exist/ca.pem");
+  }
+}
+
+// On any normal Linux/macOS host (incl. CI runners) one of the well-known
+// bundle paths must exist — this guards against the probe list going stale.
+TEST(SystemCaCerts, FindsASystemBundle) {
+  // Make sure SSL_CERT_FILE isn't masking the path-list logic.
+  const char* prev = std::getenv("SSL_CERT_FILE");
+  if (prev) unsetenv("SSL_CERT_FILE");
+
+  auto found = gizmosql::FindSystemCaCertFile();
+  ASSERT_TRUE(found.has_value())
+      << "no system CA bundle found — the probe list in system_ca_certs.h is "
+         "stale for this OS";
+  std::ifstream f(*found);
+  EXPECT_TRUE(f.good()) << "probe returned a non-readable path: " << *found;
+
+  if (prev) setenv("SSL_CERT_FILE", prev, 1);
+}


### PR DESCRIPTION
## Problem

Since v1.30.0 (the portable-Linux / `manylinux_2_28` migration), the release binaries statically link a **self-built OpenSSL** whose compiled-in default CA directory (`OPENSSLDIR`) is a **build-time path that doesn't exist at runtime**. So OpenSSL's default-verify-paths finds no trust store and **every outbound HTTPS request fails** `SSL server verification failed`:

- server-side **JWKS/OIDC discovery + key fetch** (`jwks_manager.cpp`)
- server-side **OAuth token exchange** (`oauth_http_server.cpp`)
- the **client's OAuth login flow** (`oauth_flow.cpp`)

`curl` in the same container works because it uses the distro's OpenSSL — confirming it's our binary, not the image.

## Fix

All three cpp-httplib clients now explicitly load the system CA bundle via a shared probe (`system_ca_certs.h`) that honors `$SSL_CERT_FILE` and falls back to the well-known bundle paths for Debian/Ubuntu, RHEL/Amazon Linux, SUSE, and macOS — so TLS verification works regardless of the static OpenSSL's `OPENSSLDIR`. Docker images also set `SSL_CERT_FILE`/`SSL_CERT_DIR` as defense-in-depth.

## Regression guards (so this can't silently come back)

- **`gizmosql_server --verify-tls <url>`** — a verified HTTPS GET via the same code path; exit 0 on success, 1 on failure (also a handy ops diagnostic). Validated locally: real OIDC issuers → exit 0; a self-signed cert → `SSL server verification failed` exit 1.
- **CI portable-binary smoke tests** now run `--verify-tls` against a real public OIDC endpoint in **both** `debian:bookworm-slim` and `amazonlinux:2023` (the two CA-layout families). A CA-trust regression on the actual portable binary now turns CI red — a dev-machine unit test (dynamic OpenSSL, correct CA path) would not have caught the original bug.
- **Unit tests** for the CA-probe path/env logic.

Targeting a **v1.31.1** patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
