### PR TITLE
Add --max-sessions to limit concurrent client sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **`--max-sessions` / `GIZMOSQL_MAX_SESSIONS`.** Launch-time cap on concurrent client sessions (DuckDB backend). `0` = unlimited (default). When the limit is reached, new sessions are rejected with a retriable Flight `UNAVAILABLE` error at session create (same pattern as graceful-drain rejects); existing sessions keep working. Counts sessions/connections, not people. Closes [#108](https://github.com/gizmodata/gizmosql/issues/108).
+- **`--max-sessions` / `GIZMOSQL_MAX_SESSIONS`.** Launch-time cap on concurrent non-admin client sessions (DuckDB backend). `0` = unlimited (default). When the limit is reached, new non-admin sessions are rejected with a retriable Flight `UNAVAILABLE` error at session create (same pattern as graceful-drain rejects); existing sessions keep working. Admin-role sessions skip the cap so an operator can still connect (e.g. to `KILL SESSION`). Counts sessions/connections, not people. Closes [#108](https://github.com/gizmodata/gizmosql/issues/108).
 
 ### Changed
 - Docs/README: the Metabase integration now points to GizmoData's own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`--max-sessions` / `GIZMOSQL_MAX_SESSIONS`.** Launch-time cap on concurrent client sessions (DuckDB backend). `0` = unlimited (default). When the limit is reached, new sessions are rejected with a retriable Flight `UNAVAILABLE` error at session create (same pattern as graceful-drain rejects); existing sessions keep working. Counts sessions/connections, not people. Closes [#108](https://github.com/gizmodata/gizmosql/issues/108).
+
 ### Changed
 - Docs/README: the Metabase integration now points to GizmoData's own
   [`metabase-gizmosql-driver`](https://github.com/gizmodata/metabase-gizmosql-driver)

--- a/docs/index.md
+++ b/docs/index.md
@@ -458,7 +458,7 @@ GizmoSQL can be configured via environment variables or CLI flags. Below are the
 | log-file / GIZMOSQL_LOG_FILE | Log file path; '-' => stdout; empty => stderr | stderr (if unset) | --log-file |
 | query-timeout | Query timeout in seconds (0 = unlimited) | DEFAULT_QUERY_TIMEOUT_SECONDS | --query-timeout |
 | max-metadata-size / GIZMOSQL_MAX_METADATA_SIZE | Max inbound gRPC HTTP/2 header metadata bytes per call (`GRPC_ARG_MAX_METADATA_SIZE`). Raise above the gRPC default of ~8 KB if clients send large per-call metadata (e.g. extra Apache Flight SQL JDBC URL parameters that get forwarded as gRPC headers, large bearer tokens, accumulated cookies, proxy-injected trace headers) | 0 (= use gRPC default) | --max-metadata-size |
-| max-sessions / GIZMOSQL_MAX_SESSIONS | Max concurrent client sessions (DuckDB). When reached, new sessions are rejected with a retriable UNAVAILABLE error. `0` = unlimited. Counts sessions/connections, not people | 0 | --max-sessions |
+| max-sessions / GIZMOSQL_MAX_SESSIONS | Max concurrent non-admin client sessions (DuckDB). When reached, new non-admin sessions are rejected with a retriable UNAVAILABLE error. Admin-role sessions skip the cap. `0` = unlimited. Counts sessions/connections, not people | 0 | --max-sessions |
 | query-log-level / GIZMOSQL_QUERY_LOG_LEVEL | Query log level | info (if unset) | --query-log-level |
 | auth-log-level / GIZMOSQL_AUTH_LOG_LEVEL | Authentication log level | info (if unset) | --auth-log-level |
 | session-log-level / GIZMOSQL_SESSION_LOG_LEVEL | Client session lifecycle (create/close) log level | info (if unset) | --session-log-level |

--- a/docs/index.md
+++ b/docs/index.md
@@ -458,6 +458,7 @@ GizmoSQL can be configured via environment variables or CLI flags. Below are the
 | log-file / GIZMOSQL_LOG_FILE | Log file path; '-' => stdout; empty => stderr | stderr (if unset) | --log-file |
 | query-timeout | Query timeout in seconds (0 = unlimited) | DEFAULT_QUERY_TIMEOUT_SECONDS | --query-timeout |
 | max-metadata-size / GIZMOSQL_MAX_METADATA_SIZE | Max inbound gRPC HTTP/2 header metadata bytes per call (`GRPC_ARG_MAX_METADATA_SIZE`). Raise above the gRPC default of ~8 KB if clients send large per-call metadata (e.g. extra Apache Flight SQL JDBC URL parameters that get forwarded as gRPC headers, large bearer tokens, accumulated cookies, proxy-injected trace headers) | 0 (= use gRPC default) | --max-metadata-size |
+| max-sessions / GIZMOSQL_MAX_SESSIONS | Max concurrent client sessions (DuckDB). When reached, new sessions are rejected with a retriable UNAVAILABLE error. `0` = unlimited. Counts sessions/connections, not people | 0 | --max-sessions |
 | query-log-level / GIZMOSQL_QUERY_LOG_LEVEL | Query log level | info (if unset) | --query-log-level |
 | auth-log-level / GIZMOSQL_AUTH_LOG_LEVEL | Authentication log level | info (if unset) | --auth-log-level |
 | session-log-level / GIZMOSQL_SESSION_LOG_LEVEL | Client session lifecycle (create/close) log level | info (if unset) | --session-log-level |

--- a/scripts/start_gizmosql.sh
+++ b/scripts/start_gizmosql.sh
@@ -54,6 +54,7 @@
 #   GIZMOSQL_OAUTH_INSTANCE_ID           --oauth-instance-id
 #   GIZMOSQL_OAUTH_DISABLE_TLS           --oauth-disable-tls (localhost only!)
 #   GIZMOSQL_MAX_METADATA_SIZE           --max-metadata-size
+#   GIZMOSQL_MAX_SESSIONS                --max-sessions (DuckDB only)
 #   GIZMOSQL_STORAGE_VERSION             --storage-version (DuckDB only)
 #   GIZMOSQL_MAX_CONCURRENT_STATEMENTS   --max-concurrent-statements (Enterprise)
 #   GIZMOSQL_MAX_QUEUED_STATEMENTS       --max-queued-statements (Enterprise)

--- a/scripts/start_gizmosql_slim.sh
+++ b/scripts/start_gizmosql_slim.sh
@@ -57,6 +57,7 @@
 #   GIZMOSQL_OAUTH_INSTANCE_ID           --oauth-instance-id
 #   GIZMOSQL_OAUTH_DISABLE_TLS           --oauth-disable-tls (localhost only!)
 #   GIZMOSQL_MAX_METADATA_SIZE           --max-metadata-size
+#   GIZMOSQL_MAX_SESSIONS                --max-sessions (DuckDB only)
 #   GIZMOSQL_STORAGE_VERSION             --storage-version (DuckDB only)
 #   GIZMOSQL_MAX_CONCURRENT_STATEMENTS   --max-concurrent-statements (Enterprise)
 #   GIZMOSQL_MAX_QUEUED_STATEMENTS       --max-queued-statements (Enterprise)

--- a/src/common/gizmosql_library.cpp
+++ b/src/common/gizmosql_library.cpp
@@ -537,7 +537,8 @@ arrow::Result<std::shared_ptr<flight::sql::FlightSqlServerBase>> FlightSQLServer
     const std::string& log_catalog_db_path,
     const int32_t& health_check_interval_seconds,
     const int32_t& health_check_staleness_seconds,
-    const bool& allow_unsigned_extensions) {
+    const bool& allow_unsigned_extensions,
+    const int32_t& max_sessions) {
   ARROW_ASSIGN_OR_RAISE(auto location,
                         (!tls_cert_path.empty())
                             ? flight::Location::ForGrpcTls(hostname, port)
@@ -759,6 +760,7 @@ arrow::Result<std::shared_ptr<flight::sql::FlightSqlServerBase>> FlightSQLServer
                                              admin_bypass_queue_default, memory_limit,
                                              capture_query_profile,
                                              allow_unsigned_extensions,
+                                             max_sessions,
                                              nullptr))  // No instrumentation manager yet
 
     // Set instance_id for all future log entries (enables log correlation)
@@ -1191,7 +1193,8 @@ arrow::Result<std::shared_ptr<flight::sql::FlightSqlServerBase>> CreateFlightSQL
     std::string log_catalog_db_path,
     int32_t health_check_interval_seconds,
     int32_t health_check_staleness_seconds,
-    bool allow_unsigned_extensions) {
+    bool allow_unsigned_extensions,
+    int32_t max_sessions) {
   // Reset graceful-shutdown drain state for every fresh server. The drain flags
   // are process-global; without this, a prior server that entered the draining
   // state (e.g. a previous server in the same process, as in the test binary)
@@ -1520,7 +1523,7 @@ arrow::Result<std::shared_ptr<flight::sql::FlightSqlServerBase>> CreateFlightSQL
       memory_limit, capture_query_profile, cluster_id, enable_catalog_logging,
       log_catalog, log_schema, log_catalog_db_path,
       health_check_interval_seconds, health_check_staleness_seconds,
-      allow_unsigned_extensions);
+      allow_unsigned_extensions, max_sessions);
 }
 
 arrow::Status StartFlightSQLServer(
@@ -1790,7 +1793,8 @@ int RunFlightSQLServer(const BackendType backend, fs::path database_filename,
                        int32_t shutdown_grace_period_seconds,
                        int32_t health_check_interval_seconds,
                        int32_t health_check_staleness_seconds,
-                       std::optional<bool> allow_unsigned_extensions) {
+                       std::optional<bool> allow_unsigned_extensions,
+                       int32_t max_sessions) {
   // ---- Logging normalization (library-owned) ----------------
   auto pick = [&](std::string v, const char* env_name, std::string def) -> std::string {
     if (!v.empty()) return v;
@@ -1944,6 +1948,27 @@ int RunFlightSQLServer(const BackendType backend, fs::path database_filename,
       }
     }
     if (max_concurrent_statements < 0) max_concurrent_statements = 0;
+  }
+
+  // Integer env var fallback for max_sessions: only consult env when the
+  // CLI/library caller left it at the sentinel default (0 = unlimited).
+  if (max_sessions <= 0) {
+    auto env = gizmosql::SafeGetEnvVarValue("GIZMOSQL_MAX_SESSIONS");
+    if (!env.empty()) {
+      try {
+        int parsed = std::stoi(env);
+        if (parsed > 0) {
+          max_sessions = parsed;
+        } else if (parsed < 0) {
+          std::cerr << "GIZMOSQL_MAX_SESSIONS must be a positive integer; got '"
+                    << env << "', ignoring." << std::endl;
+        }
+      } catch (const std::exception&) {
+        std::cerr << "GIZMOSQL_MAX_SESSIONS is not a valid integer ('" << env
+                  << "'), ignoring." << std::endl;
+      }
+    }
+    if (max_sessions < 0) max_sessions = 0;
   }
 
   // Capture whether the operator configured any statement-queue knob BEFORE the
@@ -2170,7 +2195,8 @@ int RunFlightSQLServer(const BackendType backend, fs::path database_filename,
       admin_bypass_queue_default.value_or(true), memory_limit, capture_profile_mode,
       cluster_id, enable_catalog_logging.value(), log_catalog, log_schema,
       log_catalog_db_path, health_check_interval_seconds,
-      health_check_staleness_seconds, allow_unsigned_extensions.value());
+      health_check_staleness_seconds, allow_unsigned_extensions.value(),
+      max_sessions);
 
   if (create_server_result.ok()) {
     auto server_ptr = create_server_result.ValueOrDie();

--- a/src/common/include/gizmosql_library.h
+++ b/src/common/include/gizmosql_library.h
@@ -262,12 +262,13 @@ int RunFlightSQLServer(
     /// operator-provided extensions (e.g. a locally mounted release bundle).
     /// nullopt = consult env var, then default off.
     std::optional<bool> allow_unsigned_extensions = std::nullopt,
-    /// Maximum number of concurrent client sessions the server will accept
-    /// (--max-sessions / GIZMOSQL_MAX_SESSIONS). When the limit is reached, new
-    /// sessions are rejected with a retriable Flight UNAVAILABLE error (same
-    /// pattern as graceful-drain rejects). 0 = unlimited. Counts sessions /
-    /// connections, not people — one IDE may consume multiple slots. DuckDB
-    /// backend only (SQLite has no ClientSession map). If 0, uses env var
-    /// GIZMOSQL_MAX_SESSIONS.
+    /// Maximum number of concurrent non-admin client sessions the server will
+    /// accept (--max-sessions / GIZMOSQL_MAX_SESSIONS). When the limit is reached,
+    /// new non-admin sessions are rejected with a retriable Flight UNAVAILABLE
+    /// error (same pattern as graceful-drain rejects). Admin-role sessions skip
+    /// the cap so an operator can still connect (e.g. to KILL SESSION). 0 =
+    /// unlimited. Counts sessions / connections, not people — one IDE may consume
+    /// multiple slots. DuckDB backend only (SQLite has no ClientSession map). If
+    /// 0, uses env var GIZMOSQL_MAX_SESSIONS.
     int32_t max_sessions = DEFAULT_MAX_SESSIONS);
 }

--- a/src/common/include/gizmosql_library.h
+++ b/src/common/include/gizmosql_library.h
@@ -42,6 +42,7 @@ const int32_t DEFAULT_MAX_METADATA_SIZE = 0;  // 0 = use gRPC default (~8 KB)
 const int32_t DEFAULT_MAX_CONCURRENT_STATEMENTS = 0;  // 0 = unlimited (queue disabled)
 const int32_t DEFAULT_MAX_QUEUED_STATEMENTS = -1;     // -1 = auto (8 x max_concurrent_statements)
 const int32_t DEFAULT_MAX_QUEUE_WAIT_SECONDS = -1;    // -1 = use built-in default (300s)
+const int32_t DEFAULT_MAX_SESSIONS = 0;               // 0 = unlimited client sessions
 
 enum class BackendType { duckdb, sqlite };
 
@@ -260,5 +261,13 @@ int RunFlightSQLServer(
     /// enabled here at startup. SECURITY: keep disabled unless loading trusted,
     /// operator-provided extensions (e.g. a locally mounted release bundle).
     /// nullopt = consult env var, then default off.
-    std::optional<bool> allow_unsigned_extensions = std::nullopt);
+    std::optional<bool> allow_unsigned_extensions = std::nullopt,
+    /// Maximum number of concurrent client sessions the server will accept
+    /// (--max-sessions / GIZMOSQL_MAX_SESSIONS). When the limit is reached, new
+    /// sessions are rejected with a retriable Flight UNAVAILABLE error (same
+    /// pattern as graceful-drain rejects). 0 = unlimited. Counts sessions /
+    /// connections, not people — one IDE may consume multiple slots. DuckDB
+    /// backend only (SQLite has no ClientSession map). If 0, uses env var
+    /// GIZMOSQL_MAX_SESSIONS.
+    int32_t max_sessions = DEFAULT_MAX_SESSIONS);
 }

--- a/src/duckdb/duckdb_server.cpp
+++ b/src/duckdb/duckdb_server.cpp
@@ -1027,7 +1027,9 @@ class DuckDBFlightSqlServer::Impl {
       }
     }
 
-    // Build the session *without* holding any lock
+    // Fill cheap session metadata without opening DuckDB. TrackedDuckDBConnection
+    // is created only after the write-lock admission check succeeds, so a
+    // rejected attempt does not create and destroy a DuckDB connection.
     auto new_session = std::make_shared<ClientSession>();
 
     new_session->server = outer_->shared_from_this();
@@ -1041,7 +1043,6 @@ class DuckDBFlightSqlServer::Impl {
     new_session->user_agent = tl_request_ctx.user_agent.value_or("");
     new_session->connection_protocol = tl_request_ctx.connection_protocol.value_or("plaintext");
     new_session->catalog_access = tl_request_ctx.catalog_access.value_or(std::vector<CatalogAccessRule>{});
-    new_session->connection = std::make_shared<gizmosql::TrackedDuckDBConnection>(*db_instance_);
     // Note: query_timeout and query_log_level are intentionally left as nullopt
     // so that sessions fall through to the server's current global values via
     // GetQueryTimeout() and GetSessionOrServerLogLevel(). This ensures that
@@ -1056,27 +1057,7 @@ class DuckDBFlightSqlServer::Impl {
       new_session->bypass_queue = admin_bypass_queue_default_;
     }
 
-#ifdef GIZMOSQL_ENTERPRISE
-    // Create session instrumentation if manager is available (Enterprise feature)
-    if (instrumentation_manager_ && instrumentation_manager_->IsEnabled()) {
-      auto instance_id = GetInstanceId();
-      if (!instance_id.empty()) {
-        new_session->instrumentation = std::make_unique<SessionInstrumentation>(
-            instrumentation_manager_, instance_id, session_id,
-            new_session->username, new_session->role, new_session->auth_method,
-            new_session->peer, new_session->peer_identity, new_session->user_agent,
-            new_session->connection_protocol);
-      } else {
-        GIZMOSQL_LOG(WARNING) << "Cannot create session instrumentation - instance_id is empty";
-      }
-    } else {
-      GIZMOSQL_LOG(DEBUG) << "Skipping session instrumentation - manager="
-                          << (instrumentation_manager_ ? "set" : "null")
-                          << ", enabled=" << (instrumentation_manager_ ? (instrumentation_manager_->IsEnabled() ? "true" : "false") : "n/a");
-    }
-#endif
-
-    // Slow path: take exclusive lock and check again
+    // Slow path: take exclusive lock, admit, then open DuckDB.
     {
       std::unique_lock write_lock(sessions_mutex_);
 
@@ -1107,6 +1088,29 @@ class DuckDBFlightSqlServer::Impl {
                 std::to_string(max_sessions_) +
                 "); not accepting new connections. Retry later.");
       }
+
+      new_session->connection =
+          std::make_shared<gizmosql::TrackedDuckDBConnection>(*db_instance_);
+
+#ifdef GIZMOSQL_ENTERPRISE
+      // Create session instrumentation if manager is available (Enterprise feature)
+      if (instrumentation_manager_ && instrumentation_manager_->IsEnabled()) {
+        auto instance_id = GetInstanceId();
+        if (!instance_id.empty()) {
+          new_session->instrumentation = std::make_unique<SessionInstrumentation>(
+              instrumentation_manager_, instance_id, session_id,
+              new_session->username, new_session->role, new_session->auth_method,
+              new_session->peer, new_session->peer_identity, new_session->user_agent,
+              new_session->connection_protocol);
+        } else {
+          GIZMOSQL_LOG(WARNING) << "Cannot create session instrumentation - instance_id is empty";
+        }
+      } else {
+        GIZMOSQL_LOG(DEBUG) << "Skipping session instrumentation - manager="
+                            << (instrumentation_manager_ ? "set" : "null")
+                            << ", enabled=" << (instrumentation_manager_ ? (instrumentation_manager_->IsEnabled() ? "true" : "false") : "n/a");
+      }
+#endif
 
       client_sessions_[session_id] = new_session;
       ::gizmosql::metrics::RecordActiveConnections(1);

--- a/src/duckdb/duckdb_server.cpp
+++ b/src/duckdb/duckdb_server.cpp
@@ -955,6 +955,20 @@ class DuckDBFlightSqlServer::Impl {
         "Session not found — it may have been evicted. Please re-connect.");
   }
 
+  // True when non-admin sessions are at --max-sessions. Admin-role sessions
+  // are excluded so an operator can still connect (e.g. to KILL SESSION).
+  // Caller must hold sessions_mutex_.
+  bool AtNonAdminSessionCap() const {
+    if (max_sessions_ <= 0) return false;
+    size_t regular = 0;
+    for (const auto& entry : client_sessions_) {
+      if (entry.second->role != "admin") {
+        if (++regular >= static_cast<size_t>(max_sessions_)) return true;
+      }
+    }
+    return false;
+  }
+
   arrow::Result<std::shared_ptr<ClientSession>> GetClientSession(
       const flight::ServerCallContext& context) {
     ARROW_ASSIGN_OR_RAISE(auto session_id, GetSessionID());
@@ -997,11 +1011,14 @@ class DuckDBFlightSqlServer::Impl {
           "Retry against another instance.");
     }
 
-    // Reject brand-new sessions when at the configured max-sessions cap.
-    // Existing sessions (fast path above) are unaffected. 0 = unlimited.
-    if (max_sessions_ > 0) {
+    // Reject brand-new *non-admin* sessions when at the configured
+    // max-sessions cap. Admin-role sessions skip the cap so an operator can
+    // still connect to run KILL SESSION (or otherwise free seats). Existing
+    // sessions (fast path above) are unaffected. 0 = unlimited.
+    const bool is_admin = tl_request_ctx.role.value_or("") == "admin";
+    if (!is_admin && max_sessions_ > 0) {
       std::shared_lock read_lock(sessions_mutex_);
-      if (client_sessions_.size() >= static_cast<size_t>(max_sessions_)) {
+      if (AtNonAdminSessionCap()) {
         return flight::MakeFlightError(
             flight::FlightStatusCode::Unavailable,
             "GizmoSQL instance has reached max-sessions (" +
@@ -1082,9 +1099,8 @@ class DuckDBFlightSqlServer::Impl {
       }
 
       // Re-check the cap under the write lock to close the race between the
-      // earlier shared-lock size check and this insert.
-      if (max_sessions_ > 0 &&
-          client_sessions_.size() >= static_cast<size_t>(max_sessions_)) {
+      // earlier shared-lock size check and this insert. Admins skip this too.
+      if (!is_admin && AtNonAdminSessionCap()) {
         return flight::MakeFlightError(
             flight::FlightStatusCode::Unavailable,
             "GizmoSQL instance has reached max-sessions (" +

--- a/src/duckdb/duckdb_server.cpp
+++ b/src/duckdb/duckdb_server.cpp
@@ -869,6 +869,7 @@ class DuckDBFlightSqlServer::Impl {
   gizmosql::QueryProfileMode capture_query_profile_ = gizmosql::QueryProfileMode::kOff;
   AdmissionController admission_controller_;  // statement-queue admission control
   bool admin_bypass_queue_default_ = true;    // admin sessions bypass the queue by default
+  int32_t max_sessions_ = 0;                  // 0 = unlimited; reject new sessions when at cap
 
   std::unordered_map<std::string, std::shared_ptr<ClientSession>> client_sessions_;
   std::unordered_map<std::string, std::string> open_transactions_;
@@ -996,6 +997,19 @@ class DuckDBFlightSqlServer::Impl {
           "Retry against another instance.");
     }
 
+    // Reject brand-new sessions when at the configured max-sessions cap.
+    // Existing sessions (fast path above) are unaffected. 0 = unlimited.
+    if (max_sessions_ > 0) {
+      std::shared_lock read_lock(sessions_mutex_);
+      if (client_sessions_.size() >= static_cast<size_t>(max_sessions_)) {
+        return flight::MakeFlightError(
+            flight::FlightStatusCode::Unavailable,
+            "GizmoSQL instance has reached max-sessions (" +
+                std::to_string(max_sessions_) +
+                "); not accepting new connections. Retry later.");
+      }
+    }
+
     // Build the session *without* holding any lock
     auto new_session = std::make_shared<ClientSession>();
 
@@ -1067,6 +1081,17 @@ class DuckDBFlightSqlServer::Impl {
         return it->second;
       }
 
+      // Re-check the cap under the write lock to close the race between the
+      // earlier shared-lock size check and this insert.
+      if (max_sessions_ > 0 &&
+          client_sessions_.size() >= static_cast<size_t>(max_sessions_)) {
+        return flight::MakeFlightError(
+            flight::FlightStatusCode::Unavailable,
+            "GizmoSQL instance has reached max-sessions (" +
+                std::to_string(max_sessions_) +
+                "); not accepting new connections. Retry later.");
+      }
+
       client_sessions_[session_id] = new_session;
       ::gizmosql::metrics::RecordActiveConnections(1);
       GIZMOSQL_LOGKV_SESSION_AT(
@@ -1118,6 +1143,7 @@ class DuckDBFlightSqlServer::Impl {
                 const int32_t& max_queue_wait_seconds,
                 const bool& admin_bypass_queue_default,
                 const gizmosql::QueryProfileMode& capture_query_profile,
+                const int32_t& max_sessions,
                 std::shared_ptr<InstrumentationManager> instrumentation_manager)
       : outer_(outer),
         db_instance_(std::move(db_instance)),
@@ -1132,6 +1158,7 @@ class DuckDBFlightSqlServer::Impl {
     admission_controller_.SetMaxQueued(max_queued_statements);
     admission_controller_.SetDefaultMaxQueueWaitSeconds(max_queue_wait_seconds);
     admin_bypass_queue_default_ = admin_bypass_queue_default;
+    max_sessions_ = max_sessions;
   }
 
   std::shared_ptr<InstrumentationManager> GetInstrumentationManager() const {
@@ -1158,7 +1185,8 @@ class DuckDBFlightSqlServer::Impl {
                 const int32_t& max_queued_statements,
                 const int32_t& max_queue_wait_seconds,
                 const bool& admin_bypass_queue_default,
-                const gizmosql::QueryProfileMode& capture_query_profile)
+                const gizmosql::QueryProfileMode& capture_query_profile,
+                const int32_t& max_sessions)
       : outer_(outer),
         db_instance_(std::move(db_instance)),
         print_queries_(print_queries),
@@ -1171,6 +1199,7 @@ class DuckDBFlightSqlServer::Impl {
     admission_controller_.SetMaxQueued(max_queued_statements);
     admission_controller_.SetDefaultMaxQueueWaitSeconds(max_queue_wait_seconds);
     admin_bypass_queue_default_ = admin_bypass_queue_default;
+    max_sessions_ = max_sessions;
   }
 #endif
 
@@ -2253,7 +2282,7 @@ Result<std::shared_ptr<DuckDBFlightSqlServer>> DuckDBFlightSqlServer::Create(
     const int32_t& max_queued_statements, const int32_t& max_queue_wait_seconds,
     const bool& admin_bypass_queue_default, const std::string& memory_limit,
     const gizmosql::QueryProfileMode& capture_query_profile,
-    const bool& allow_unsigned_extensions,
+    const bool& allow_unsigned_extensions, const int32_t& max_sessions,
 #ifdef GIZMOSQL_ENTERPRISE
     std::shared_ptr<InstrumentationManager> instrumentation_manager) {
 #else
@@ -2327,13 +2356,18 @@ Result<std::shared_ptr<DuckDBFlightSqlServer>> DuckDBFlightSqlServer::Create(
       result.get(), db, print_queries, query_timeout, query_log_level,
       session_log_level, max_concurrent_statements, max_queued_statements,
       max_queue_wait_seconds, admin_bypass_queue_default, capture_query_profile,
-      instrumentation_manager);
+      max_sessions, instrumentation_manager);
 #else
   result->impl_ = std::make_shared<DuckDBFlightSqlServer::Impl>(
       result.get(), db, print_queries, query_timeout, query_log_level,
       session_log_level, max_concurrent_statements, max_queued_statements,
-      max_queue_wait_seconds, admin_bypass_queue_default, capture_query_profile);
+      max_queue_wait_seconds, admin_bypass_queue_default, capture_query_profile,
+      max_sessions);
 #endif
+
+  if (max_sessions > 0) {
+    GIZMOSQL_LOG(INFO) << "Max client sessions set to: " << max_sessions;
+  }
 
   // Use dynamic SQL info that queries DuckDB for keywords and functions
   for (const auto& id_to_result : GetSqlInfoResultMap(result.get(), query_timeout)) {

--- a/src/duckdb/duckdb_server.h
+++ b/src/duckdb/duckdb_server.h
@@ -59,7 +59,7 @@ class DuckDBFlightSqlServer : public flight::sql::FlightSqlServerBase,
       const int32_t& max_queued_statements, const int32_t& max_queue_wait_seconds,
       const bool& admin_bypass_queue_default, const std::string& memory_limit,
       const gizmosql::QueryProfileMode& capture_query_profile,
-      const bool& allow_unsigned_extensions,
+      const bool& allow_unsigned_extensions, const int32_t& max_sessions,
 #ifdef GIZMOSQL_ENTERPRISE
       std::shared_ptr<InstrumentationManager> instrumentation_manager = nullptr);
 #else

--- a/src/gizmosql_server.cpp
+++ b/src/gizmosql_server.cpp
@@ -153,10 +153,12 @@ int main(int argc, char** argv) {
              "built-in default (80% of physical RAM). If empty, uses env var GIZMOSQL_MEMORY_LIMIT. "
              "Ignored for the SQLite backend.")
             ("max-sessions", po::value<int32_t>()->default_value(DEFAULT_MAX_SESSIONS),
-             "Maximum number of concurrent client sessions the server will accept. When the "
-             "limit is reached, new sessions are rejected with a retriable UNAVAILABLE error. "
-             "0 = unlimited. Counts sessions/connections (not people); one IDE may use multiple "
-             "slots. DuckDB backend only. If 0, uses env var GIZMOSQL_MAX_SESSIONS.")
+             "Maximum number of concurrent non-admin client sessions the server will accept. "
+             "When the limit is reached, new non-admin sessions are rejected with a retriable "
+             "UNAVAILABLE error. Admin-role sessions always get in (so an operator can still "
+             "connect and KILL SESSION). 0 = unlimited. Counts sessions/connections (not people); "
+             "one IDE may use multiple slots. DuckDB backend only. If 0, uses env var "
+             "GIZMOSQL_MAX_SESSIONS.")
             ("allow-unsigned-extensions", po::value<bool>()->default_value(false),
              "Allow loading unsigned DuckDB extensions (DuckDB's allow_unsigned_extensions "
              "setting). This setting is GLOBAL_ONLY in DuckDB - it cannot be changed via SET or "

--- a/src/gizmosql_server.cpp
+++ b/src/gizmosql_server.cpp
@@ -152,6 +152,11 @@ int main(int argc, char** argv) {
              "DuckDB's `memory_limit` setting (global / instance-wide). Empty leaves DuckDB's "
              "built-in default (80% of physical RAM). If empty, uses env var GIZMOSQL_MEMORY_LIMIT. "
              "Ignored for the SQLite backend.")
+            ("max-sessions", po::value<int32_t>()->default_value(DEFAULT_MAX_SESSIONS),
+             "Maximum number of concurrent client sessions the server will accept. When the "
+             "limit is reached, new sessions are rejected with a retriable UNAVAILABLE error. "
+             "0 = unlimited. Counts sessions/connections (not people); one IDE may use multiple "
+             "slots. DuckDB backend only. If 0, uses env var GIZMOSQL_MAX_SESSIONS.")
             ("allow-unsigned-extensions", po::value<bool>()->default_value(false),
              "Allow loading unsigned DuckDB extensions (DuckDB's allow_unsigned_extensions "
              "setting). This setting is GLOBAL_ONLY in DuckDB - it cannot be changed via SET or "
@@ -461,6 +466,8 @@ int main(int argc, char** argv) {
 
   std::string memory_limit = vm["memory-limit"].as<std::string>();
 
+  int32_t max_sessions = vm["max-sessions"].as<int32_t>();
+
   std::optional<bool> allow_unsigned_extensions =
       vm["allow-unsigned-extensions"].defaulted()
           ? std::nullopt
@@ -584,5 +591,5 @@ int main(int argc, char** argv) {
       cluster_id, enable_catalog_logging, log_catalog, log_schema, log_catalog_db_path,
       graceful_shutdown, shutdown_grace_period_seconds,
       health_check_interval_seconds, health_check_staleness_seconds,
-      allow_unsigned_extensions);
+      allow_unsigned_extensions, max_sessions);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ enable_testing()
 set(GIZMOSQL_CORE_TEST_SRCS
         integration/test_admission_controller.cpp
         integration/test_active_session_count.cpp
+        integration/test_max_sessions.cpp
         integration/test_auth_log_level.cpp
         integration/test_authentication.cpp
         integration/test_bulk_ingest.cpp

--- a/tests/integration/test_max_sessions.cpp
+++ b/tests/integration/test_max_sessions.cpp
@@ -1,0 +1,143 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Integration tests for --max-sessions / GIZMOSQL_MAX_SESSIONS.
+// New sessions beyond the cap are rejected with Flight UNAVAILABLE (same
+// pattern as graceful-drain rejects). Existing sessions keep working.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "arrow/api.h"
+#include "arrow/flight/sql/client.h"
+#include "arrow/flight/types.h"
+#include "arrow/testing/gtest_util.h"
+#include "duckdb_server.h"
+#include "test_server_fixture.h"
+
+using arrow::flight::sql::FlightSqlClient;
+
+namespace {
+
+struct HeldClient {
+  std::unique_ptr<FlightSqlClient> sql_client;
+  arrow::flight::FlightCallOptions call_options;
+};
+
+arrow::Result<HeldClient> ConnectAndExecute(int port, const std::string& username,
+                                            const std::string& password,
+                                            const std::string& sql = "SELECT 1") {
+  arrow::flight::FlightClientOptions opts;
+  ARROW_ASSIGN_OR_RAISE(auto location,
+                        arrow::flight::Location::ForGrpcTcp("localhost", port));
+  ARROW_ASSIGN_OR_RAISE(auto flight_client,
+                        arrow::flight::FlightClient::Connect(location, opts));
+  ARROW_ASSIGN_OR_RAISE(auto bearer,
+                        flight_client->AuthenticateBasicToken({}, username, password));
+
+  HeldClient held;
+  held.call_options.headers.push_back(bearer);
+  held.sql_client = std::make_unique<FlightSqlClient>(std::move(flight_client));
+  ARROW_ASSIGN_OR_RAISE(auto info, held.sql_client->Execute(held.call_options, sql));
+  for (const auto& endpoint : info->endpoints()) {
+    ARROW_ASSIGN_OR_RAISE(auto reader,
+                          held.sql_client->DoGet(held.call_options, endpoint.ticket));
+    ARROW_RETURN_NOT_OK(reader->ToTable().status());
+  }
+  return held;
+}
+
+arrow::Status ExecuteOn(HeldClient& held, const std::string& sql) {
+  ARROW_ASSIGN_OR_RAISE(auto info, held.sql_client->Execute(held.call_options, sql));
+  for (const auto& endpoint : info->endpoints()) {
+    ARROW_ASSIGN_OR_RAISE(auto reader,
+                          held.sql_client->DoGet(held.call_options, endpoint.ticket));
+    ARROW_RETURN_NOT_OK(reader->ToTable().status());
+  }
+  return arrow::Status::OK();
+}
+
+}  // namespace
+
+class MaxSessionsFixture
+    : public gizmosql::testing::ServerTestFixture<MaxSessionsFixture> {
+ public:
+  static gizmosql::testing::TestServerConfig GetConfig() {
+    return {
+        .database_filename = "max_sessions_test.db",
+        .port = 31420,
+        .health_port = 31421,
+        .username = "testuser",
+        .password = "testpassword",
+        .enable_instrumentation = false,
+        .max_sessions = 2,
+    };
+  }
+};
+
+template <>
+std::shared_ptr<arrow::flight::sql::FlightSqlServerBase>
+    gizmosql::testing::ServerTestFixture<MaxSessionsFixture>::server_{};
+template <>
+std::thread gizmosql::testing::ServerTestFixture<MaxSessionsFixture>::server_thread_{};
+template <>
+std::atomic<bool>
+    gizmosql::testing::ServerTestFixture<MaxSessionsFixture>::server_ready_{false};
+template <>
+gizmosql::testing::TestServerConfig
+    gizmosql::testing::ServerTestFixture<MaxSessionsFixture>::config_{};
+
+TEST_F(MaxSessionsFixture, UnderCapSucceeds) {
+  ASSERT_TRUE(IsServerReady());
+  auto r = ConnectAndExecute(GetPort(), GetUsername(), GetPassword());
+  ASSERT_TRUE(r.ok()) << r.status().ToString();
+}
+
+TEST_F(MaxSessionsFixture, RejectsBeyondCapWithUnavailable) {
+  ASSERT_TRUE(IsServerReady());
+
+  auto duckdb_server =
+      std::dynamic_pointer_cast<gizmosql::ddb::DuckDBFlightSqlServer>(server_);
+  ASSERT_NE(duckdb_server, nullptr);
+
+  auto c1 = ConnectAndExecute(GetPort(), GetUsername(), GetPassword());
+  ASSERT_TRUE(c1.ok()) << c1.status().ToString();
+  auto c2 = ConnectAndExecute(GetPort(), GetUsername(), GetPassword());
+  ASSERT_TRUE(c2.ok()) << c2.status().ToString();
+  EXPECT_EQ(duckdb_server->GetActiveSessionCount(), 2u);
+
+  auto overflow = ConnectAndExecute(GetPort(), GetUsername(), GetPassword());
+  ASSERT_FALSE(overflow.ok()) << "third session should be rejected at max-sessions=2";
+  const std::string err = overflow.status().ToString();
+  EXPECT_NE(err.find("max-sessions"), std::string::npos) << err;
+  EXPECT_NE(err.find("Unavailable"), std::string::npos) << err;
+
+  // Existing session still works after the reject.
+  ASSERT_TRUE(ExecuteOn(*c1, "SELECT 2").ok());
+
+  // Close one session explicitly; a new client should be admitted.
+  ASSERT_OK(c2->sql_client->CloseSession(c2->call_options,
+                                         arrow::flight::CloseSessionRequest{})
+                .status());
+  EXPECT_LT(duckdb_server->GetActiveSessionCount(), 2u);
+
+  auto c3 = ConnectAndExecute(GetPort(), GetUsername(), GetPassword());
+  ASSERT_TRUE(c3.ok()) << c3.status().ToString();
+}

--- a/tests/integration/test_max_sessions.cpp
+++ b/tests/integration/test_max_sessions.cpp
@@ -25,7 +25,9 @@
 #include <atomic>
 #include <chrono>
 #include <cstdlib>
+#include <iomanip>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <utility>
 
@@ -71,9 +73,14 @@ arrow::Result<HeldClient> ConnectAndExecute(int port, const std::string& usernam
 
 // Username/password Basic auth always gets role "admin". Non-admin sessions
 // (the ones the cap applies to) are minted JWTs with role "user".
+// Session ids must be UUID hex: KILL SESSION only matches [0-9a-fA-F-]+, so a
+// label like "max-sessions-user-N" is not recognized as a kill command.
 std::string MintUserToken() {
   static std::atomic<int> n{0};
-  const std::string session_id = "max-sessions-user-" + std::to_string(++n);
+  std::ostringstream ss;
+  ss << "aaaaaaaa-0000-4000-8000-" << std::hex << std::setw(12) << std::setfill('0')
+     << ++n;
+  const std::string session_id = ss.str();
   return jwt::create()
       .set_issuer("gizmosql")
       .set_type("JWT")

--- a/tests/integration/test_max_sessions.cpp
+++ b/tests/integration/test_max_sessions.cpp
@@ -16,11 +16,15 @@
 // under the License.
 
 // Integration tests for --max-sessions / GIZMOSQL_MAX_SESSIONS.
-// New sessions beyond the cap are rejected with Flight UNAVAILABLE (same
-// pattern as graceful-drain rejects). Existing sessions keep working.
+// New non-admin sessions beyond the cap are rejected with Flight UNAVAILABLE
+// (same pattern as graceful-drain rejects). Existing sessions keep working.
+// Admin-role sessions skip the cap so an operator can still connect.
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
 #include <memory>
 #include <string>
 #include <utility>
@@ -30,6 +34,7 @@
 #include "arrow/flight/types.h"
 #include "arrow/testing/gtest_util.h"
 #include "duckdb_server.h"
+#include "jwt-cpp/jwt.h"
 #include "test_server_fixture.h"
 
 using arrow::flight::sql::FlightSqlClient;
@@ -64,6 +69,45 @@ arrow::Result<HeldClient> ConnectAndExecute(int port, const std::string& usernam
   return held;
 }
 
+// Username/password Basic auth always gets role "admin". Non-admin sessions
+// (the ones the cap applies to) are minted JWTs with role "user".
+std::string MintUserToken() {
+  static std::atomic<int> n{0};
+  const std::string session_id = "max-sessions-user-" + std::to_string(++n);
+  return jwt::create()
+      .set_issuer("gizmosql")
+      .set_type("JWT")
+      .set_id(session_id)
+      .set_issued_at(std::chrono::system_clock::now())
+      .set_expires_at(std::chrono::system_clock::now() + std::chrono::seconds{3600})
+      .set_payload_claim("sub", jwt::claim(std::string("analyst")))
+      .set_payload_claim("role", jwt::claim(std::string("user")))
+      .set_payload_claim("auth_method", jwt::claim(std::string("Basic")))
+      .set_payload_claim("instance_id", jwt::claim(std::string("max-sessions-instance")))
+      .set_payload_claim("session_id", jwt::claim(session_id))
+      .sign(jwt::algorithm::hs256{"test_secret_key_for_testing"});
+}
+
+arrow::Result<HeldClient> ConnectUserAndExecute(int port,
+                                                const std::string& sql = "SELECT 1") {
+  arrow::flight::FlightClientOptions opts;
+  ARROW_ASSIGN_OR_RAISE(auto location,
+                        arrow::flight::Location::ForGrpcTcp("localhost", port));
+  ARROW_ASSIGN_OR_RAISE(auto flight_client,
+                        arrow::flight::FlightClient::Connect(location, opts));
+
+  HeldClient held;
+  held.call_options.headers.emplace_back("authorization", "Bearer " + MintUserToken());
+  held.sql_client = std::make_unique<FlightSqlClient>(std::move(flight_client));
+  ARROW_ASSIGN_OR_RAISE(auto info, held.sql_client->Execute(held.call_options, sql));
+  for (const auto& endpoint : info->endpoints()) {
+    ARROW_ASSIGN_OR_RAISE(auto reader,
+                          held.sql_client->DoGet(held.call_options, endpoint.ticket));
+    ARROW_RETURN_NOT_OK(reader->ToTable().status());
+  }
+  return held;
+}
+
 arrow::Status ExecuteOn(HeldClient& held, const std::string& sql) {
   ARROW_ASSIGN_OR_RAISE(auto info, held.sql_client->Execute(held.call_options, sql));
   for (const auto& endpoint : info->endpoints()) {
@@ -72,6 +116,30 @@ arrow::Status ExecuteOn(HeldClient& held, const std::string& sql) {
     ARROW_RETURN_NOT_OK(reader->ToTable().status());
   }
   return arrow::Status::OK();
+}
+
+void CloseHeld(HeldClient& held) {
+  (void)held.sql_client->CloseSession(held.call_options,
+                                      arrow::flight::CloseSessionRequest{});
+}
+
+arrow::Result<std::string> QueryScalarString(HeldClient& held, const std::string& sql) {
+  ARROW_ASSIGN_OR_RAISE(auto info, held.sql_client->Execute(held.call_options, sql));
+  for (const auto& endpoint : info->endpoints()) {
+    ARROW_ASSIGN_OR_RAISE(auto reader,
+                          held.sql_client->DoGet(held.call_options, endpoint.ticket));
+    ARROW_ASSIGN_OR_RAISE(auto table, reader->ToTable());
+    if (table->num_rows() > 0) {
+      auto array = std::static_pointer_cast<arrow::StringArray>(table->column(0)->chunk(0));
+      return array->GetString(0);
+    }
+  }
+  return arrow::Status::Invalid("no rows");
+}
+
+bool IsEnterpriseLicenseAvailable() {
+  const char* license_file = std::getenv("GIZMOSQL_LICENSE_KEY_FILE");
+  return license_file != nullptr && license_file[0] != '\0';
 }
 
 }  // namespace
@@ -87,6 +155,8 @@ class MaxSessionsFixture
         .username = "testuser",
         .password = "testpassword",
         .enable_instrumentation = false,
+        // Self-minted non-admin tokens use an arbitrary instance_id.
+        .allow_cross_instance_tokens = true,
         .max_sessions = 2,
     };
   }
@@ -106,8 +176,9 @@ gizmosql::testing::TestServerConfig
 
 TEST_F(MaxSessionsFixture, UnderCapSucceeds) {
   ASSERT_TRUE(IsServerReady());
-  auto r = ConnectAndExecute(GetPort(), GetUsername(), GetPassword());
+  auto r = ConnectUserAndExecute(GetPort());
   ASSERT_TRUE(r.ok()) << r.status().ToString();
+  CloseHeld(*r);
 }
 
 TEST_F(MaxSessionsFixture, RejectsBeyondCapWithUnavailable) {
@@ -117,14 +188,14 @@ TEST_F(MaxSessionsFixture, RejectsBeyondCapWithUnavailable) {
       std::dynamic_pointer_cast<gizmosql::ddb::DuckDBFlightSqlServer>(server_);
   ASSERT_NE(duckdb_server, nullptr);
 
-  auto c1 = ConnectAndExecute(GetPort(), GetUsername(), GetPassword());
+  auto c1 = ConnectUserAndExecute(GetPort());
   ASSERT_TRUE(c1.ok()) << c1.status().ToString();
-  auto c2 = ConnectAndExecute(GetPort(), GetUsername(), GetPassword());
+  auto c2 = ConnectUserAndExecute(GetPort());
   ASSERT_TRUE(c2.ok()) << c2.status().ToString();
   EXPECT_EQ(duckdb_server->GetActiveSessionCount(), 2u);
 
-  auto overflow = ConnectAndExecute(GetPort(), GetUsername(), GetPassword());
-  ASSERT_FALSE(overflow.ok()) << "third session should be rejected at max-sessions=2";
+  auto overflow = ConnectUserAndExecute(GetPort());
+  ASSERT_FALSE(overflow.ok()) << "third non-admin session should be rejected at max-sessions=2";
   const std::string err = overflow.status().ToString();
   EXPECT_NE(err.find("max-sessions"), std::string::npos) << err;
   EXPECT_NE(err.find("Unavailable"), std::string::npos) << err;
@@ -138,6 +209,44 @@ TEST_F(MaxSessionsFixture, RejectsBeyondCapWithUnavailable) {
                 .status());
   EXPECT_LT(duckdb_server->GetActiveSessionCount(), 2u);
 
-  auto c3 = ConnectAndExecute(GetPort(), GetUsername(), GetPassword());
+  auto c3 = ConnectUserAndExecute(GetPort());
   ASSERT_TRUE(c3.ok()) << c3.status().ToString();
+  CloseHeld(*c1);
+  CloseHeld(*c3);
+}
+
+TEST_F(MaxSessionsFixture, AdminBypassesCapAndKillFreesSlot) {
+  ASSERT_TRUE(IsServerReady());
+
+  auto c1 = ConnectUserAndExecute(GetPort());
+  ASSERT_TRUE(c1.ok()) << c1.status().ToString();
+  auto c2 = ConnectUserAndExecute(GetPort());
+  ASSERT_TRUE(c2.ok()) << c2.status().ToString();
+
+  auto overflow = ConnectUserAndExecute(GetPort());
+  ASSERT_FALSE(overflow.ok()) << "non-admin should be rejected at cap";
+
+  // Username/password Basic auth is role "admin" and must still get in.
+  auto admin = ConnectAndExecute(GetPort(), GetUsername(), GetPassword());
+  ASSERT_TRUE(admin.ok()) << admin.status().ToString();
+  ASSERT_TRUE(ExecuteOn(*admin, "SELECT 1").ok());
+
+  if (!IsEnterpriseLicenseAvailable()) {
+    CloseHeld(*c1);
+    CloseHeld(*c2);
+    CloseHeld(*admin);
+    GTEST_SKIP() << "Enterprise license required to prove KILL SESSION frees a slot. "
+                 << "Set GIZMOSQL_LICENSE_KEY_FILE.";
+  }
+
+  auto session_id = QueryScalarString(*c1, "SELECT GIZMOSQL_CURRENT_SESSION()");
+  ASSERT_TRUE(session_id.ok()) << session_id.status().ToString();
+
+  ASSERT_TRUE(ExecuteOn(*admin, "KILL SESSION '" + *session_id + "'").ok());
+
+  auto c3 = ConnectUserAndExecute(GetPort());
+  ASSERT_TRUE(c3.ok()) << c3.status().ToString();
+  CloseHeld(*admin);
+  CloseHeld(*c2);
+  CloseHeld(*c3);
 }

--- a/tests/integration/test_server_fixture.h
+++ b/tests/integration/test_server_fixture.h
@@ -87,7 +87,8 @@ CreateFlightSQLServer(
     std::string log_catalog_db_path = "",
     int32_t health_check_interval_seconds = 0,
     int32_t health_check_staleness_seconds = 0,
-    bool allow_unsigned_extensions = false);
+    bool allow_unsigned_extensions = false,
+    int32_t max_sessions = 0);
 
 // Cleanup function to reset global state between test suites
 void CleanupServerResources();
@@ -147,6 +148,7 @@ struct TestServerConfig {
   int32_t health_check_interval_seconds = 0;     // Seconds between health checks (0 => env var, then 5)
   int32_t health_check_staleness_seconds = 0;    // NOT_SERVING if no check completed in this window (0 => env var, then 3x interval)
   bool allow_unsigned_extensions = false;        // [DuckDB] allow loading unsigned extensions (GLOBAL_ONLY, set at open)
+  int32_t max_sessions = 0;                      // max concurrent client sessions (0 = unlimited)
 };
 
 /// CRTP-based test fixture template for integration tests.
@@ -265,7 +267,8 @@ class ServerTestFixture : public ::testing::Test {
         /*log_catalog_db_path=*/config_.log_catalog_db_path,
         /*health_check_interval_seconds=*/config_.health_check_interval_seconds,
         /*health_check_staleness_seconds=*/config_.health_check_staleness_seconds,
-        /*allow_unsigned_extensions=*/config_.allow_unsigned_extensions);
+        /*allow_unsigned_extensions=*/config_.allow_unsigned_extensions,
+        /*max_sessions=*/config_.max_sessions);
 
     ASSERT_TRUE(result.ok()) << "Failed to create server: " << result.status().ToString();
     server_ = *result;


### PR DESCRIPTION
## Summary
I added a launch-time `--max-sessions` cap so the server can refuse new client sessions once it’s full (Flight `UNAVAILABLE`), instead of accepting unlimited connections.

I worked through a few overload scenarios before implementing changes:

1. **Can we keep creating sessions forever?** Yes. I understand that this change is supposed to put a hard ceiling on this.
2. **Can sessions skew to one user (e.g. one IDE with multiple connections)?** Yes. But this doesn't impact the user's experience
3. **Are idle sessions cleaned up?** Not automatically, they can still occupy slots. 

A question for discussion on this one; from my understanding `max_sessions` places a cap on number of sessions to avoid overwhelming the system. But, what happens to old quiet connections that still hold a slot. Right now an admin would need to manually find a session ID to kill it. Don't we want to have to have idle sessions cleaned up

I'm curious why we wouldn't implement some idle timeout. Such that if a session hasn't had work for X minutes, we drop it and free up the slot.

I'm envisioning this resembling how endusers use GizmoSQL; sometimes connections are made and never closed cleanly. This seems directionally relevant to the limiting connections to avoid crashing the system. We are protecting against jobs on counts but not against capacity being tied up by clients that aren't doing work?

I suppose this is being tracked here: https://github.com/gizmodata/gizmosql/issues/141

4. **What about a few sessions running huge queries?** That’s already covered by the existing server-wide memory limit (and statement queuing when licensed) .
5. **What happens if someone connects at the cap?** I used this guide the error handling; reject at session create with a clear retriable `UNAVAILABLE`. I followed the same pattern as graceful drain.

Closes #108.

## Testing plan
I wrote an integration test (`test_max_sessions.cpp`) for max-sessions: under the cap a session can connect and query, a new session is rejected with UNAVAILABLE once the server is full, existing sessions keep working after that reject, and CloseSession frees a slot for a new client.

I blogged my reasoning in more detail for this and #186 here for added context:
https://www.linkedin.com/pulse/preparing-palantir-interview-solving-open-source-issues-sibanda-hbs9e/

Made with [Cursor](https://cursor.com)